### PR TITLE
Let staff members create custom embed messages

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -32,6 +32,7 @@ client.load_extension('bot.cogs.moderation')
 client.load_extension('bot.cogs.information')
 client.load_extension('bot.cogs.clean')
 client.load_extension('bot.cogs.announcements')
+client.load_extension('bot.cogs.chat')
 client.load_extension('bot.cogs.fun')
 
 if constants.Bot.token:

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -32,7 +32,7 @@ client.load_extension('bot.cogs.moderation')
 client.load_extension('bot.cogs.information')
 client.load_extension('bot.cogs.clean')
 client.load_extension('bot.cogs.announcements')
-client.load_extension('bot.cogs.chat')
+client.load_extension('bot.cogs.embeds')
 client.load_extension('bot.cogs.fun')
 
 if constants.Bot.token:

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -1,0 +1,12 @@
+from bot.bot import Bot
+from discord.ext.commands import Cog
+
+
+class Chat(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+
+def setup(bot: Bot) -> None:
+    '''Load the Chat cog.'''
+    bot.add_cog(Chat(bot))

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -1,12 +1,14 @@
-import textwrap
 from collections import defaultdict
 
-from discord import Colour, Embed, TextChannel
+from discord import Embed, TextChannel, Colour
 from discord.ext.commands import Cog, Context, command
 
 from bot import constants
 from bot.bot import Bot
+
 from bot.cogs.moderation.modlog import ModLog
+import textwrap
+
 
 prefix = constants.Bot.prefix
 
@@ -32,17 +34,17 @@ class Chat(Cog):
     async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
         if not self.embed_mode[ctx.author]:
-            await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}embedhelp` for more info")
+            await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}help Embed` for more info")
             self.embed_mode[ctx.author] = True
             self.embed[ctx.author] = Embed()
         else:
-            await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}embedhelp` for more info")
+            await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
 
     @command()
     async def embedquit(self, ctx: Context) -> None:
         """Leave embed creation mode"""
         if self.embed_mode[ctx.author]:
-            await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, any unsent embeds were cleared")
+            await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, your embed was cleared")
             self.embed_mode[ctx.author] = False
             del self.embed[ctx.author]
         else:
@@ -51,38 +53,49 @@ class Chat(Cog):
     @command()
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
-        try:
-            await ctx.send(embed=self.embed[ctx.author])
-        except KeyError:
-            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}embedhelp`)")
+        embed = self.get_embed(ctx)
+
+        if not embed:
+            return
+
+        await ctx.send(embed=embed)
 
     @command()
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        try:
-            channel_perms = channel.permissions_for(ctx.author)
-            if channel_perms.send_messages:
-                embed_msg = await channel.send(embed=self.embed[ctx.author])
-                await self.mod_log.send_log_message(
-                    icon_url=constants.Icons.message_edit,
-                    colour=Colour.blurple(),
-                    title="Embed message sent",
-                    thumbnail=ctx.author.avatar_url_as(static_format="png"),
-                    text=textwrap.dedent(f"""
-                        Actor: {ctx.author.mention} (`{ctx.author.id}`)
-                        Channel: {channel.mention}
-                        Message jump link: {embed_msg.jump_url}
-                    """),
-                )
-                await ctx.send(":white_check_mark: Embed sent")
-            else:
-                await ctx.send(f":x: Sorry, {ctx.author.mention} you don't have permission to send messages to this channel")
-        except KeyError:
-            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}embedhelp`)")
+        embed = self.get_embed(ctx)
+
+        if not embed:
+            return
+
+        channel_perms = channel.permissions_for(ctx.author)
+        if channel_perms.send_messages:
+            embed_msg = await channel.send(embed=embed)
+
+            await self.mod_log.send_log_message(
+                icon_url=constants.Icons.message_edit,
+                colour=Colour.blurple(),
+                title="Embed message sent",
+                thumbnail=ctx.author.avatar_url_as(static_format="png"),
+                text=textwrap.dedent(f"""
+                    Actor: {ctx.author.mention} (`{ctx.author.id}`)
+                    Channel: {channel.mention}
+                    Message jump link: {embed_msg.jump_url}
+                """),
+            )
+            await ctx.send(":white_check_mark: Embed sent")
 
     # endregion
     # region: embed build
     # endregion
+
+    async def get_embed(self, ctx):
+        try:
+            embed = self.embed[ctx.author]
+        except KeyError:
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}help Embed`)")
+            return False
+        return embed
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -1,10 +1,54 @@
 from bot.bot import Bot
-from discord.ext.commands import Cog
+from discord import Embed, TextChannel
+from discord.ext.commands import Cog, Context, command
+from collections import defaultdict
+from bot import constants
+
+
+prefix = constants.Bot.prefix
 
 
 class Chat(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.embed_mode = defaultdict(bool)
+        self.embed = {}
+
+    @command(alias=["embedbuild "])
+    async def embed(self, ctx: Context) -> None:
+        """Enter embed creation mode"""
+        if not self.embed_mode[ctx.author]:
+            await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}embedhelp` for more info")
+            self.embed_mode[ctx.author] = True
+            self.embed[ctx.author] = Embed()
+        else:
+            await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}embedhelp` for more info")
+
+    @command(hidden=True)
+    async def embedquit(self, ctx: Context) -> None:
+        if self.embed_mode[ctx.author]:
+            await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, any unsent embeds were cleared")
+            self.embed_mode[ctx.author] = False
+            del self.embed[ctx.author]
+        else:
+            await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
+
+    @command(hidden=True)
+    async def embedshow(self, ctx: Context) -> None:
+        try:
+            await ctx.send(embed=self.embed[ctx.author])
+        except KeyError:
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}embedhelp`)")
+
+    @command(hidden=True)
+    async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
+        """Send the Embed"""
+        pass
+
+    @command(hidden=True)
+    async def embedhelp(self, ctx: Context) -> None:
+        """Show help page for embed creation"""
+        pass
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -52,7 +52,15 @@ class Chat(Cog):
     @command()
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        pass
+        try:
+            channel_perms = channel.permissions_for(ctx.author)
+            if channel_perms.send_messages:
+                await channel.send(embed=self.embed[ctx.author])
+                await ctx.send(":white_check_mark: Embed sent")
+            else:
+                await ctx.send(f":x: Sorry, {ctx.author.mention} you don't have permission to send messages to this channel")
+        except KeyError:
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}embedhelp`)")
 
     # endregion
     # region: embed build

--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -1,21 +1,28 @@
-from bot.bot import Bot
+from collections import defaultdict
+
 from discord import Embed, TextChannel
 from discord.ext.commands import Cog, Context, command
-from collections import defaultdict
-from bot import constants
 
+from bot import constants
+from bot.bot import Bot
 
 prefix = constants.Bot.prefix
 
 
 class Chat(Cog):
+    """
+    A cog which allows user to send messages using the bot
+    """
+
     def __init__(self, bot: Bot):
         self.bot = bot
         self.embed_mode = defaultdict(bool)
         self.embed = {}
 
-    @command(alias=["embedbuild "])
-    async def embed(self, ctx: Context) -> None:
+    # region: embed mode
+
+    @command(alias=["embed", "embedcreate"])
+    async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
         if not self.embed_mode[ctx.author]:
             await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}embedhelp` for more info")
@@ -24,8 +31,9 @@ class Chat(Cog):
         else:
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}embedhelp` for more info")
 
-    @command(hidden=True)
+    @command()
     async def embedquit(self, ctx: Context) -> None:
+        """Leave embed creation mode"""
         if self.embed_mode[ctx.author]:
             await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, any unsent embeds were cleared")
             self.embed_mode[ctx.author] = False
@@ -33,22 +41,22 @@ class Chat(Cog):
         else:
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
 
-    @command(hidden=True)
+    @command()
     async def embedshow(self, ctx: Context) -> None:
+        """Take a look at the embed"""
         try:
             await ctx.send(embed=self.embed[ctx.author])
         except KeyError:
             await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}embedhelp`)")
 
-    @command(hidden=True)
+    @command()
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
-        """Send the Embed"""
+        """Send the Embed to specified channel"""
         pass
 
-    @command(hidden=True)
-    async def embedhelp(self, ctx: Context) -> None:
-        """Show help page for embed creation"""
-        pass
+    # endregion
+    # region: embed build
+    # endregion
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -10,11 +10,15 @@ from bot.cogs.moderation.modlog import ModLog
 from bot.constants import MODERATION_ROLES
 from bot.constants import Bot as BotConstant
 from bot.constants import Icons
-from bot.decorators import with_role
+from bot.decorators import with_role, has_active_embed
 
 prefix = BotConstant.prefix
 
 log = logging.getLogger(__name__)
+
+
+# Global variable needed for the `check_embed` decorator to work
+embeds = {}
 
 
 class Embeds(Cog):
@@ -25,7 +29,6 @@ class Embeds(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
         self.embed_mode = defaultdict(bool)
-        self.embed = {}
         self.embed_field_id = defaultdict(lambda: -1)
 
     @property
@@ -42,7 +45,7 @@ class Embeds(Cog):
         if not self.embed_mode[ctx.author]:
             await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}help Embed` for more info")
             self.embed_mode[ctx.author] = True
-            self.embed[ctx.author] = Embed()
+            embeds[ctx.author] = Embed()
         else:
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
 
@@ -53,29 +56,23 @@ class Embeds(Cog):
         if self.embed_mode[ctx.author]:
             await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, your embed was cleared")
             self.embed_mode[ctx.author] = False
-            del self.embed[ctx.author]
+            del embeds[ctx.author]
         else:
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
 
     @command()
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        await ctx.send(embed=embed)
+        await ctx.send(embed=embeds[ctx.author])
 
     @command()
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
+        embed = embeds[ctx.author]
 
         channel_perms = channel.permissions_for(ctx.author)
         if channel_perms.send_messages:
@@ -107,112 +104,85 @@ class Embeds(Cog):
 
     @embed_group.command(name="title")
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_title(self, ctx: Context, *, title: str) -> None:
         """Set embeds title"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.title = title
-        self.embed[ctx.author] = embed
+        embeds[ctx.author].title = title
         await ctx.send("Embeds title updated")
 
     @embed_group.command(name="description")
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_description(self, ctx: Context, *, description: str) -> None:
         """Set embeds title"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.description = description
-        self.embed[ctx.author] = embed
+        embeds[ctx.author].description = description
         await ctx.send("Embeds description updated")
 
     @embed_group.command(name="footer")
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:
         """Set embeds footer"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.set_footer(text=footer)
-        self.embed[ctx.author] = embed
+        embeds[ctx.author].set_footer(text=footer)
         await ctx.send("Embeds footer updated")
 
     @embed_group.command(name="image", aliases=["img"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_image(self, ctx: Context, *, url: str) -> None:
         """Set embeds image"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.set_image(url=url)
-        self.embed[ctx.author] = embed
+        embeds[ctx.author].set_image(url=url)
         await ctx.send("Embeds Image URL updated")
 
     @embed_group.command(name="color", aliases=["colour"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_color(self, ctx: Context, *, color: ColourConverter) -> None:
         """Set embeds title, `color` can be HEX color or some of standard colors (red, blue, ...)"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.colour = color
-        self.embed[ctx.author] = embed
+        embeds[ctx.author].colour = color
         await ctx.send("Embeds color updated")
 
     # region: author
     @embed_group.command(name="author", aliases=["setauthor", "authorname"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_author_name(self, ctx: Context, *, author_name: str) -> None:
         """Set authors name in embed"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.set_author(name=author_name, url=embed.author.url,
-                         icon_url=embed.author.icon_url)
-        self.embed[ctx.author] = embed
+        embed = embeds[ctx.author]
+        embed.set_author(
+            name=author_name,
+            url=embed.author.url,
+            icon_url=embed.author.icon_url
+        )
+        # TODO: Check if there is no need to update the embeds list
         await ctx.send("Embeds author updated")
 
     @embed_group.command(name="authorurl", aliases=["setauthorurl"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_author_url(self, ctx: Context, *, author_url: str) -> None:
         """Set authors URL in embed"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
-        embed.set_author(name=embed.author.name, url=author_url,
-                         icon_url=embed.author.icon_url)
-        self.embed[ctx.author] = embed
+        embed = embeds[ctx.author]
+        embed.set_author(
+            name=embed.author.name,
+            url=author_url,
+            icon_url=embed.author.icon_url
+        )
         await ctx.send("Embeds author URL updated")
 
     @embed_group.command(name="authoricon", aliases=[
         "setauthoricon", "authoriconurl", "setauthoriconurl"
     ])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_author_icon(self, ctx: Context, *, icon_url: str) -> None:
-        """Set authors image in embed"""
-        embed = await self.get_embed(ctx)
 
-        if embed is False:
-            return
-
-        embed.set_author(name=embed.author.name, url=embed.author.url,
-                         icon_url=icon_url)
-        self.embed[ctx.author] = embed
+        embed = embeds[ctx.author]
+        embed.set_author(
+            name=embed.author.name,
+            url=embed.author.url,
+            icon_url=icon_url
+        )
         await ctx.send("Embeds authors image updated")
     # endregion
 
@@ -222,74 +192,64 @@ class Embeds(Cog):
         "fieldadd", "fieldcreate", "fieldmake", "field"
     ])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
         """Create new field in embed"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
+        embed = embeds[ctx.author]
         embed.add_field(name=title, value="None")
-
         self.embed_field_id[ctx.author] += 1
-        self.embed[ctx.author] = embed
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
     @embed_group.command(name="fielddescription", aliases=["fieldvalue"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_field_description(self, ctx: Context, ID: int, *, description: str) -> None:
         """Set description of embeds field"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
+        embed = embeds[ctx.author]
         embed.set_field_at(
-            ID, name=embed.fields[ID].name, value=description)
-
-        self.embed[ctx.author] = embed
+            ID,
+            name=embed.fields[ID].name,
+            value=description
+        )
         await ctx.send(f"Embed field with ID: **{ID}** updated")
 
     @embed_group.command(name="fieldtitle", aliases=["fieldname"])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_field_title(self, ctx: Context, ID: int, *, title: str) -> None:
         """Set title of embeds field"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
+        embed = embeds[ctx.author]
         embed.set_field_at(
-            ID, name=title, value=embed.fields[ID].value)
-
-        self.embed[ctx.author] = embed
+            ID,
+            name=title,
+            value=embed.fields[ID].value
+        )
         await ctx.send(f"Embed field with ID: **{ID}** updated")
 
     @embed_group.command(name="fieldinline")
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_field_inline(self, ctx: Context, ID: int, inline: bool) -> None:
         """Choose if embed should be inline or not"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
+        embed = embeds[ctx.author]
         embed.set_field_at(
-            ID, name=embed.fields[ID].name, value=embed.fields[ID].value, inline=inline)
-
-        self.embed[ctx.author] = embed
+            ID,
+            name=embed.fields[ID].name,
+            value=embed.fields[ID].value,
+            inline=inline
+        )
         await ctx.send(f"Embed field with ID: **{ID}** updated")
 
     @embed_group.command(name="removefield", aliases=[
@@ -297,33 +257,19 @@ class Embeds(Cog):
         "fielddel", "delfield", "remfield"
     ])
     @with_role(*MODERATION_ROLES)
+    @has_active_embed(embeds)
     async def embed_field_remove(self, ctx: Context, ID: int) -> None:
         """Remove field in embed"""
-        embed = await self.get_embed(ctx)
-
-        if embed is False:
-            return
-
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
+        embed = embeds[ctx.author]
         embed.remove_field(ID)
-
-        self.embed[ctx.author] = embed
         self.embed_field_id[ctx.author] -= 1
         await ctx.send(f"Embed field with ID: **{ID}** removed (all other IDs were renumbered accordingly)")
     # endregion
     # endregion
-
-    async def get_embed(self, ctx: Context) -> Embed:
-        """Return the authors embed or send error message and return `False`"""
-        try:
-            embed = self.embed[ctx.author]
-        except KeyError:
-            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}help Embeds`)")
-            return False
-        return embed
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -2,14 +2,16 @@ import textwrap
 from collections import defaultdict
 
 from discord import Colour, Embed, TextChannel
-from discord.ext.commands import Cog, Context, command, group, ColourConverter
+from discord.ext.commands import Cog, ColourConverter, Context, command, group
 
-from bot import constants
 from bot.bot import Bot
 from bot.cogs.moderation.modlog import ModLog
+from bot.constants import MODERATION_ROLES
+from bot.constants import Bot as BotConstant
+from bot.constants import Icons
 from bot.decorators import with_role
 
-prefix = constants.Bot.prefix
+prefix = BotConstant.prefix
 
 
 class Embeds(Cog):
@@ -31,7 +33,7 @@ class Embeds(Cog):
     # region: embed mode
 
     @command(aliases=["embedcreate"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
         if not self.embed_mode[ctx.author]:
@@ -42,7 +44,7 @@ class Embeds(Cog):
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
 
     @command()
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embedquit(self, ctx: Context) -> None:
         """Leave embed creation mode"""
         if self.embed_mode[ctx.author]:
@@ -53,7 +55,7 @@ class Embeds(Cog):
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
 
     @command()
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
         embed = await self.get_embed(ctx)
@@ -64,7 +66,7 @@ class Embeds(Cog):
         await ctx.send(embed=embed)
 
     @command()
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
         embed = await self.get_embed(ctx)
@@ -77,7 +79,7 @@ class Embeds(Cog):
             embed_msg = await channel.send(embed=embed)
 
             await self.mod_log.send_log_message(
-                icon_url=constants.Icons.message_edit,
+                icon_url=Icons.message_edit,
                 colour=Colour.blurple(),
                 title="Embed message sent",
                 thumbnail=ctx.author.avatar_url_as(static_format="png"),
@@ -94,13 +96,13 @@ class Embeds(Cog):
     # endregion
     # region: embed build
     @group(invoke_without_command=True, name='embed', aliases=["embedset"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_group(self, ctx: Context) -> None:
         """Commands for configuring the Embed message"""
         await ctx.invoke(self.bot.get_command('help'), 'embed')
 
     @embed_group.command(name="title")
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_title(self, ctx: Context, *, title: str) -> None:
         """Set embeds title"""
         embed = await self.get_embed(ctx)
@@ -113,7 +115,7 @@ class Embeds(Cog):
         await ctx.send("Embeds title updated")
 
     @embed_group.command(name="description")
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_description(self, ctx: Context, *, description: str) -> None:
         """Set embeds title"""
         embed = await self.get_embed(ctx)
@@ -126,7 +128,7 @@ class Embeds(Cog):
         await ctx.send("Embeds description updated")
 
     @embed_group.command(name="footer")
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:
         """Set embeds footer"""
         embed = await self.get_embed(ctx)
@@ -139,7 +141,7 @@ class Embeds(Cog):
         await ctx.send("Embeds footer updated")
 
     @embed_group.command(name="image", aliases=["img"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_image(self, ctx: Context, *, url: str) -> None:
         """Set embeds image"""
         embed = await self.get_embed(ctx)
@@ -152,7 +154,7 @@ class Embeds(Cog):
         await ctx.send("Embeds Image URL updated")
 
     @embed_group.command(name="color", aliases=["colour"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_color(self, ctx: Context, *, color: ColourConverter) -> None:
         """Set embeds title, `color` can be HEX color or some of standard colors (red, blue, ...)"""
         embed = await self.get_embed(ctx)
@@ -166,7 +168,7 @@ class Embeds(Cog):
 
     # region: author
     @embed_group.command(name="author", aliases=["setauthor", "authorname"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_author_name(self, ctx: Context, *, author_name: str) -> None:
         """Set authors name in embed"""
         embed = await self.get_embed(ctx)
@@ -180,7 +182,7 @@ class Embeds(Cog):
         await ctx.send("Embeds author updated")
 
     @embed_group.command(name="authorurl", aliases=["setauthorurl"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_author_url(self, ctx: Context, *, author_url: str) -> None:
         """Set authors URL in embed"""
         embed = await self.get_embed(ctx)
@@ -196,7 +198,7 @@ class Embeds(Cog):
     @embed_group.command(name="authoricon", aliases=[
         "setauthoricon", "authoriconurl", "setauthoriconurl"
     ])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_author_icon(self, ctx: Context, *, icon_url: str) -> None:
         """Set authors image in embed"""
         embed = await self.get_embed(ctx)
@@ -215,7 +217,7 @@ class Embeds(Cog):
         "newfield", "makefield", "addfield",
         "fieldadd", "fieldcreate", "fieldmake", "field"
     ])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
         """Create new field in embed"""
         embed = await self.get_embed(ctx)
@@ -230,7 +232,7 @@ class Embeds(Cog):
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
     @embed_group.command(name="fielddescription", aliases=["fieldvalue"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_field_description(self, ctx: Context, ID: int, *, description: str) -> None:
         """Set description of embeds field"""
         embed = await self.get_embed(ctx)
@@ -249,7 +251,7 @@ class Embeds(Cog):
         await ctx.send(f"Embed field with ID: **{ID}** updated")
 
     @embed_group.command(name="fieldtitle", aliases=["fieldname"])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_field_value(self, ctx: Context, ID: int, *, title: str) -> None:
         """Set title of embeds field"""
         embed = await self.get_embed(ctx)
@@ -268,7 +270,7 @@ class Embeds(Cog):
         await ctx.send(f"Embed field with ID: **{ID}** updated")
 
     @embed_group.command(name="fieldinline")
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_field_inline(self, ctx: Context, ID: int, inline: bool) -> None:
         """Choose if embed should be inline or not"""
         embed = await self.get_embed(ctx)
@@ -290,7 +292,7 @@ class Embeds(Cog):
         "deletefield", "fieldremove", "fieldrem",
         "fielddel", "delfield", "remfield"
     ])
-    @with_role(*constants.MODERATION_ROLES)
+    @with_role(*MODERATION_ROLES)
     async def embed_field_remove(self, ctx: Context, ID: int) -> None:
         """Remove field in embed"""
         embed = await self.get_embed(ctx)

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -207,7 +207,7 @@ class Embeds(Cog):
     # region: fields
     @embed_group.command(name="createfield", aliases=[
         "newfield", "makefield", "addfield",
-        "fieldadd", "fieldcreate", "fieldmake"
+        "fieldadd", "fieldcreate", "fieldmake", "field"
     ])
     @with_role(*constants.MODERATION_ROLES)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
@@ -223,7 +223,7 @@ class Embeds(Cog):
         self.embed[ctx.author] = embed
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
-    @embed_group.command(name="fieldvalue", aliases=["fielddescription"])
+    @embed_group.command(name="fielddescription", aliases=["fieldvalue"])
     @with_role(*constants.MODERATION_ROLES)
     async def embed_field_description(self, ctx: Context, ID: int, *, description: str) -> None:
         """Set description of embeds field"""
@@ -299,6 +299,7 @@ class Embeds(Cog):
         embed.remove_field(ID)
 
         self.embed[ctx.author] = embed
+        self.embed_field_id[ctx.author] -= 1
         await ctx.send(f"Embed field with ID: **{ID}** removed (all other IDs were renumbered accordingly)")
     # endregion
     # endregion

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -53,9 +53,9 @@ class Embeds(Cog):
     @command()
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
-        embed = self.get_embed(ctx)
+        embed = await self.get_embed(ctx)
 
-        if not embed:
+        if embed is False:
             return
 
         await ctx.send(embed=embed)
@@ -63,9 +63,9 @@ class Embeds(Cog):
     @command()
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        embed = self.get_embed(ctx)
+        embed = await self.get_embed(ctx)
 
-        if not embed:
+        if embed is False:
             return
 
         channel_perms = channel.permissions_for(ctx.author)

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -158,6 +158,52 @@ class Embeds(Cog):
         self.embed[ctx.author] = embed
         await ctx.send("Embeds color updated")
 
+    # region: author
+    @embed_group.command(name="author", aliases=["setauthor", "authorname"])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_author_name(self, ctx: Context, *, author_name: str) -> None:
+        """Set authors name in embed"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.set_author(name=author_name, url=embed.author.url,
+                         icon_url=embed.author.icon_url)
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds author updated")
+
+    @embed_group.command(name="authorurl", aliases=["setauthorurl"])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_author_url(self, ctx: Context, *, author_url: str) -> None:
+        """Set authors URL in embed"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.set_author(name=embed.author.name, url=author_url,
+                         icon_url=embed.author.icon_url)
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds author URL updated")
+
+    @embed_group.command(name="authoricon", aliases=[
+        "setauthoricon", "authoriconurl", "setauthoriconurl"
+    ])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_author_icon(self, ctx: Context, *, icon_url: str) -> None:
+        """Set authors image in embed"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.set_author(name=embed.author.name, url=embed.author.url,
+                         icon_url=icon_url)
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds authors image updated")
+    # endregion
+
     # region: fields
     @embed_group.command(name="createfield", aliases=[
         "newfield", "makefield", "addfield",

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -2,7 +2,7 @@ import textwrap
 from collections import defaultdict
 
 from discord import Colour, Embed, TextChannel
-from discord.ext.commands import Cog, Context, command, group
+from discord.ext.commands import Cog, Context, command, group, ColourConverter
 
 from bot import constants
 from bot.bot import Bot
@@ -144,6 +144,18 @@ class Embeds(Cog):
         self.embed[ctx.author] = embed
         await ctx.send("Embeds Image URL updated")
 
+    @embed_group.command(name="color", aliases=["colour"])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_color(self, ctx: Context, *, color: ColourConverter) -> None:
+        """Set embeds title, `color` can be `rgb(x, y, z)` or `hsv(x, y, z)`"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.colour = color
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds color updated")
     # endregion
 
     async def get_embed(self, ctx):

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -252,7 +252,7 @@ class Embeds(Cog):
 
     @embed_group.command(name="fieldtitle", aliases=["fieldname"])
     @with_role(*MODERATION_ROLES)
-    async def embed_field_value(self, ctx: Context, ID: int, *, title: str) -> None:
+    async def embed_field_title(self, ctx: Context, ID: int, *, title: str) -> None:
         """Set title of embeds field"""
         embed = await self.get_embed(ctx)
 

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -44,9 +44,8 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
-        if not self.embed_mode[ctx.author]:
+        if ctx.author not in embeds:
             await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}help Embed` for more info")
-            self.embed_mode[ctx.author] = True
             embeds[ctx.author] = Embed()
         else:
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
@@ -55,9 +54,8 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embedquit(self, ctx: Context) -> None:
         """Leave embed creation mode"""
-        if self.embed_mode[ctx.author]:
+        if ctx.author in embeds:
             await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, your embed was cleared")
-            self.embed_mode[ctx.author] = False
             del embeds[ctx.author]
         else:
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
@@ -74,11 +72,9 @@ class Embeds(Cog):
     @has_active_embed(embeds)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        embed = embeds[ctx.author]
-
         channel_perms = channel.permissions_for(ctx.author)
         if channel_perms.send_messages:
-            embed_msg = await channel.send(embed=embed)
+            embed_msg = await channel.send(embed=embeds[ctx.author])
 
             await self.mod_log.send_log_message(
                 icon_url=Icons.message_edit,
@@ -156,7 +152,6 @@ class Embeds(Cog):
             url=embed.author.url,
             icon_url=embed.author.icon_url
         )
-        # TODO: Check if there is no need to update the embeds list
         await ctx.send("Embeds author updated")
 
     @embed_group.command(name="authorurl", aliases=["setauthorurl"])
@@ -200,8 +195,7 @@ class Embeds(Cog):
     @has_active_embed(embeds)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
         """Create new field in embed"""
-        embed = embeds[ctx.author]
-        embed.add_field(name=title, value="None")
+        embeds[ctx.author].add_field(name=title, value="None")
         self.embed_field_id[ctx.author] += 1
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
@@ -269,8 +263,7 @@ class Embeds(Cog):
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
-        embed = embeds[ctx.author]
-        embed.remove_field(ID)
+        embeds[ctx.author].remove_field(ID)
         self.embed_field_id[ctx.author] -= 1
         await ctx.send(f"Embed field with ID: **{ID}** removed (all other IDs were renumbered accordingly)")
     # endregion

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -1,5 +1,6 @@
 import logging
 import textwrap
+import typing as t
 from collections import defaultdict
 
 from discord import Colour, Embed, TextChannel
@@ -10,7 +11,8 @@ from bot.cogs.moderation.modlog import ModLog
 from bot.constants import MODERATION_ROLES
 from bot.constants import Bot as BotConstant
 from bot.constants import Icons
-from bot.decorators import with_role, has_active_embed
+from bot.decorators import has_active_embed, with_role
+from bot.utils.converters import FetchedMember
 
 prefix = BotConstant.prefix
 
@@ -175,15 +177,18 @@ class Embeds(Cog):
     ])
     @with_role(*MODERATION_ROLES)
     @has_active_embed(embeds)
-    async def embed_author_icon(self, ctx: Context, *, icon_url: str) -> None:
-
+    async def embed_author_icon(self, ctx: Context, *, icon_url: t.Union[FetchedMember, str]) -> None:
+        """Set authors icon in embed (You can also mention user to get his avatar)"""
         embed = embeds[ctx.author]
+        if type(icon_url) != str:
+            icon_url = icon_url.avatar_url_as(format="png")
         embed.set_author(
             name=embed.author.name,
             url=embed.author.url,
             icon_url=icon_url
         )
         await ctx.send("Embeds authors image updated")
+
     # endregion
 
     # region: fields

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -1,3 +1,4 @@
+import logging
 import textwrap
 from collections import defaultdict
 
@@ -12,6 +13,8 @@ from bot.constants import Icons
 from bot.decorators import with_role
 
 prefix = BotConstant.prefix
+
+log = logging.getLogger(__name__)
 
 
 class Embeds(Cog):
@@ -89,6 +92,7 @@ class Embeds(Cog):
                     Message jump link: {embed_msg.jump_url}
                 """),
             )
+            log.info(f"User {ctx.author} sent embed message to #{channel}")
             await ctx.send(":white_check_mark: Embed sent")
         else:
             await ctx.send(f":x: {ctx.author.mention} Sorry but you don't have permission to send messages to this channel")

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -30,7 +30,6 @@ class Embeds(Cog):
 
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.embed_mode = defaultdict(bool)
         self.embed_field_id = defaultdict(lambda: -1)
 
     @property

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -105,6 +105,18 @@ class Embeds(Cog):
         embed.title = title
         self.embed[ctx.author] = embed
         await ctx.send("Embeds title updated")
+
+    @embed_group.command(name="footer")
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_footer(self, ctx: Context, *, footer: str) -> None:
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.set_footer(text=footer)
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds footer updated")
     # endregion
 
     async def get_embed(self, ctx):

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -13,7 +13,7 @@ import textwrap
 prefix = constants.Bot.prefix
 
 
-class Chat(Cog):
+class Embeds(Cog):
     """
     A cog which allows user to send messages using the bot
     """
@@ -93,11 +93,11 @@ class Chat(Cog):
         try:
             embed = self.embed[ctx.author]
         except KeyError:
-            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}help Embed`)")
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{prefix}help Embeds`)")
             return False
         return embed
 
 
 def setup(bot: Bot) -> None:
-    '''Load the Chat cog.'''
-    bot.add_cog(Chat(bot))
+    '''Load the Embeds cog.'''
+    bot.add_cog(Embeds(bot))

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -88,6 +88,8 @@ class Embeds(Cog):
                 """),
             )
             await ctx.send(":white_check_mark: Embed sent")
+        else:
+            await ctx.send(f":x: {ctx.author.mention} Sorry but you don't have permission to send messages to this channel")
 
     # endregion
     # region: embed build

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -31,6 +31,7 @@ class Embeds(Cog):
     # region: embed mode
 
     @command(aliases=["embedcreate"])
+    @with_role(*constants.MODERATION_ROLES)
     async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
         if not self.embed_mode[ctx.author]:
@@ -41,6 +42,7 @@ class Embeds(Cog):
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
 
     @command()
+    @with_role(*constants.MODERATION_ROLES)
     async def embedquit(self, ctx: Context) -> None:
         """Leave embed creation mode"""
         if self.embed_mode[ctx.author]:
@@ -51,6 +53,7 @@ class Embeds(Cog):
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
 
     @command()
+    @with_role(*constants.MODERATION_ROLES)
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
         embed = await self.get_embed(ctx)
@@ -61,6 +64,7 @@ class Embeds(Cog):
         await ctx.send(embed=embed)
 
     @command()
+    @with_role(*constants.MODERATION_ROLES)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
         embed = await self.get_embed(ctx)

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 
 from discord import Embed, TextChannel, Colour
-from discord.ext.commands import Cog, Context, command
+from discord.ext.commands import Cog, Context, command, group
 
 from bot import constants
 from bot.bot import Bot
+from bot.decorators import with_role
 
 from bot.cogs.moderation.modlog import ModLog
 import textwrap
@@ -87,6 +88,23 @@ class Embeds(Cog):
 
     # endregion
     # region: embed build
+    @group(invoke_without_command=True, name='embed', aliases=["embedset"])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_group(self, ctx: Context) -> None:
+        '''Commands for configuring the Embed message'''
+        await ctx.invoke(self.bot.get_command('help'), 'embed')
+
+    @embed_group.command(name="title")
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_title(self, ctx: Context, *, title: str) -> None:
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.title = title
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds title updated")
     # endregion
 
     async def get_embed(self, ctx):

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -1,15 +1,13 @@
+import textwrap
 from collections import defaultdict
 
-from discord import Embed, TextChannel, Colour
+from discord import Colour, Embed, TextChannel
 from discord.ext.commands import Cog, Context, command, group
 
 from bot import constants
 from bot.bot import Bot
-from bot.decorators import with_role
-
 from bot.cogs.moderation.modlog import ModLog
-import textwrap
-
+from bot.decorators import with_role
 
 prefix = constants.Bot.prefix
 
@@ -97,6 +95,7 @@ class Embeds(Cog):
     @embed_group.command(name="title")
     @with_role(*constants.MODERATION_ROLES)
     async def embed_title(self, ctx: Context, *, title: str) -> None:
+        """Set embeds title"""
         embed = await self.get_embed(ctx)
 
         if embed is False:
@@ -109,6 +108,7 @@ class Embeds(Cog):
     @embed_group.command(name="footer")
     @with_role(*constants.MODERATION_ROLES)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:
+        """Set embeds footer"""
         embed = await self.get_embed(ctx)
 
         if embed is False:
@@ -117,6 +117,20 @@ class Embeds(Cog):
         embed.set_footer(text=footer)
         self.embed[ctx.author] = embed
         await ctx.send("Embeds footer updated")
+
+    @embed_group.command(name="image", aliases=["img"])
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_image(self, ctx: Context, *, url: str) -> None:
+        """Set embeds image (not passing URL will remove the image)"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.set_image(url=url)
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds Image URL updated")
+
     # endregion
 
     async def get_embed(self, ctx):

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -105,6 +105,19 @@ class Embeds(Cog):
         self.embed[ctx.author] = embed
         await ctx.send("Embeds title updated")
 
+    @embed_group.command(name="description")
+    @with_role(*constants.MODERATION_ROLES)
+    async def embed_description(self, ctx: Context, *, description: str) -> None:
+        """Set embeds title"""
+        embed = await self.get_embed(ctx)
+
+        if embed is False:
+            return
+
+        embed.description = description
+        self.embed[ctx.author] = embed
+        await ctx.send("Embeds description updated")
+
     @embed_group.command(name="footer")
     @with_role(*constants.MODERATION_ROLES)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -240,7 +240,7 @@ class Embeds(Cog):
         if embed is False:
             return
 
-        if self.embed_field_id[ctx.author] < ID:
+        if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
@@ -259,7 +259,7 @@ class Embeds(Cog):
         if embed is False:
             return
 
-        if self.embed_field_id[ctx.author] < ID:
+        if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
@@ -278,7 +278,7 @@ class Embeds(Cog):
         if embed is False:
             return
 
-        if self.embed_field_id[ctx.author] < ID:
+        if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
@@ -300,7 +300,7 @@ class Embeds(Cog):
         if embed is False:
             return
 
-        if self.embed_field_id[ctx.author] < ID:
+        if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -19,7 +19,7 @@ prefix = BotConstant.prefix
 log = logging.getLogger(__name__)
 
 
-# Global variable needed for the `check_embed` decorator to work
+# Global variable needed for the `has_active_embed` decorator to work
 embeds = {}
 
 

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -231,10 +231,9 @@ def respect_role_hierarchy(target_arg: Union[int, str] = 0) -> Callable:
 def has_active_embed(embeds: dict) -> Callable:
     """Make sure that the author has an active embed in the `embeds` dict"""
     async def predicate(ctx) -> bool:
-        try:
-            embeds[ctx.author]
-        except KeyError:
+        if ctx.author in embeds:
+            return True
+        else:
             await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{Bot.prefix}help Embeds`)")
             return False
-        return True
     return commands.check(predicate)

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -11,7 +11,7 @@ from discord.errors import NotFound
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Cog, Context
 
-from bot.constants import ERROR_REPLIES, RedirectOutput
+from bot.constants import ERROR_REPLIES, Bot, RedirectOutput
 from bot.utils.checks import with_role_check, without_role_check
 
 log = logging.getLogger(__name__)
@@ -226,3 +226,15 @@ def respect_role_hierarchy(target_arg: Union[int, str] = 0) -> Callable:
                 await func(self, ctx, *args, **kwargs)
         return inner
     return wrap
+
+
+def has_active_embed(embeds: dict) -> Callable:
+    """Make sure that the author has an active embed in the `embeds` dict"""
+    async def predicate(ctx) -> bool:
+        try:
+            embeds[ctx.author]
+        except KeyError:
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{Bot.prefix}help Embeds`)")
+            return False
+        return True
+    return commands.check(predicate)


### PR DESCRIPTION
Closes #9 

Created **embeds** cog, that adds the ability to create embeds for `MODERATION_ROLES`.

The commands added:
- `!embedbuild` (Enter the embed building mode)
- `!embedquit` (Leave the embed building mode)
- `!embedshow` (Preview the embed before sending it)
- `!embedsend <channel>` (Send the finished embed to specified channel)
- `!embed` (Group of embed building commands)
    - `!embed title <title>` (Set embeds title)
    - `!embed description <description>` (Set embeds description)
    - `!embed footer <footer>` (Set footer)
    - `!embed image <url>` (Add image to embed)
    - `!embed color <color>` (Set color of the embed)
    - `!embed author <name>` (Set name of author)
    - `!embed authorurl <url>` (Set authors url)
    - `!embed authoricon <url>` (Set authors icon)
    -  `!embed createfield <title>` (Create new title) [Will show user the ID]
    - `!embed fielddescription <ID> <description> ` (Set fields description)
    - `!embed fieldtitle <ID> <title>` (Set fields title)
    - `!embed fieldinline <ID> <bool>` (Should the field be inline?)
    - `!embed removefield <ID>` (Remove specified field)

This will make it easier to create longer and nicer messages for staff members.
This feature is only available for `MODERATION_ROLES` because regular staff members shouldn't need to use embeds.

The final result can look something like this:
![image](https://user-images.githubusercontent.com/20902250/82680393-7b66be80-9c4c-11ea-9216-9f55ecd2543c.png)

