### PR TITLE
Refactor the !help command.

### DIFF
--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -180,7 +180,7 @@ class Clean(Cog):
     @with_role(*STAFF_ROLES)
     async def clean_group(self, ctx: Context) -> None:
         '''Commands for cleaning messages in channels.'''
-        await ctx.invoke(self.bot.get_command('help'), 'clean')
+        await ctx.send_help(ctx.command)
 
     @clean_group.command(name='user', aliases=['users'])
     @with_role(*STAFF_ROLES)

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -11,7 +11,7 @@ from bot.cogs.moderation.modlog import ModLog
 from bot.constants import MODERATION_ROLES
 from bot.constants import Bot as BotConstant
 from bot.constants import Icons
-from bot.decorators import has_active_embed, with_role
+from bot.decorators import with_role
 from bot.utils.converters import FetchedMember
 
 prefix = BotConstant.prefix
@@ -61,16 +61,20 @@ class Embeds(Cog):
 
     @command()
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         await ctx.send(embed=embeds[ctx.author])
 
     @command()
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         channel_perms = channel.permissions_for(ctx.author)
         if channel_perms.send_messages:
             embed_msg = await channel.send(embed=embeds[ctx.author])
@@ -101,50 +105,62 @@ class Embeds(Cog):
 
     @embed_group.command(name="title")
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_title(self, ctx: Context, *, title: str) -> None:
         """Set embeds title"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].title = title
         await ctx.send("Embeds title updated")
 
     @embed_group.command(name="description")
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_description(self, ctx: Context, *, description: str) -> None:
         """Set embeds title"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].description = description
         await ctx.send("Embeds description updated")
 
     @embed_group.command(name="footer")
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:
         """Set embeds footer"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].set_footer(text=footer)
         await ctx.send("Embeds footer updated")
 
     @embed_group.command(name="image", aliases=["img"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_image(self, ctx: Context, *, url: str) -> None:
         """Set embeds image"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].set_image(url=url)
         await ctx.send("Embeds Image URL updated")
 
     @embed_group.command(name="color", aliases=["colour"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_color(self, ctx: Context, *, color: ColourConverter) -> None:
         """Set embeds title, `color` can be HEX color or some of standard colors (red, blue, ...)"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].colour = color
         await ctx.send("Embeds color updated")
 
     # region: author
     @embed_group.command(name="author", aliases=["setauthor", "authorname"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_author_name(self, ctx: Context, *, author_name: str) -> None:
         """Set authors name in embed"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embed = embeds[ctx.author]
         embed.set_author(
             name=author_name,
@@ -155,9 +171,11 @@ class Embeds(Cog):
 
     @embed_group.command(name="authorurl", aliases=["setauthorurl"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_author_url(self, ctx: Context, *, author_url: str) -> None:
         """Set authors URL in embed"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embed = embeds[ctx.author]
         embed.set_author(
             name=embed.author.name,
@@ -170,9 +188,11 @@ class Embeds(Cog):
         "setauthoricon", "authoriconurl", "setauthoriconurl"
     ])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_author_icon(self, ctx: Context, *, icon_url: t.Union[FetchedMember, str]) -> None:
         """Set authors icon in embed (You can also mention user to get his avatar)"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embed = embeds[ctx.author]
         if type(icon_url) != str:
             icon_url = icon_url.avatar_url_as(format="png")
@@ -191,18 +211,21 @@ class Embeds(Cog):
         "fieldadd", "fieldcreate", "fieldmake", "field"
     ])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
         """Create new field in embed"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         embeds[ctx.author].add_field(name=title, value="None")
         self.embed_field_id[ctx.author] += 1
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
     @embed_group.command(name="fielddescription", aliases=["fieldvalue"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_field_description(self, ctx: Context, ID: int, *, description: str) -> None:
         """Set description of embeds field"""
+        if not await Embeds.has_active_embed(ctx):
+            return
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
@@ -217,9 +240,10 @@ class Embeds(Cog):
 
     @embed_group.command(name="fieldtitle", aliases=["fieldname"])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_field_title(self, ctx: Context, ID: int, *, title: str) -> None:
         """Set title of embeds field"""
+        if not await Embeds.has_active_embed(ctx):
+            return
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
@@ -234,9 +258,11 @@ class Embeds(Cog):
 
     @embed_group.command(name="fieldinline")
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_field_inline(self, ctx: Context, ID: int, inline: bool) -> None:
         """Choose if embed should be inline or not"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
@@ -255,9 +281,11 @@ class Embeds(Cog):
         "fielddel", "delfield", "remfield"
     ])
     @with_role(*MODERATION_ROLES)
-    @has_active_embed(embeds)
     async def embed_field_remove(self, ctx: Context, ID: int) -> None:
         """Remove field in embed"""
+        if not await Embeds.has_active_embed(ctx):
+            return
+
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
@@ -267,6 +295,14 @@ class Embeds(Cog):
         await ctx.send(f"Embed field with ID: **{ID}** removed (all other IDs were renumbered accordingly)")
     # endregion
     # endregion
+
+    @staticmethod
+    async def has_active_embed(ctx):
+        if ctx.author in embeds:
+            return True
+        else:
+            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{Bot.prefix}help Embeds`)")
+            return False
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -101,7 +101,7 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_group(self, ctx: Context) -> None:
         """Commands for configuring the Embed message"""
-        await ctx.invoke(self.bot.get_command('help'), 'embed')
+        await ctx.send_help(ctx.command)
 
     @embed_group.command(name="title")
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/embeds.py
+++ b/bot/cogs/embeds.py
@@ -19,10 +19,6 @@ prefix = BotConstant.prefix
 log = logging.getLogger(__name__)
 
 
-# Global variable needed for the `has_active_embed` decorator to work
-embeds = {}
-
-
 class Embeds(Cog):
     """
     A cog which allows user to send messages using the bot
@@ -30,6 +26,7 @@ class Embeds(Cog):
 
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.embeds = {}
         self.embed_field_id = defaultdict(lambda: -1)
 
     @property
@@ -43,9 +40,9 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embedbuild(self, ctx: Context) -> None:
         """Enter embed creation mode"""
-        if ctx.author not in embeds:
+        if ctx.author not in self.embeds:
             await ctx.send(f"{ctx.author.mention} You are now in embed creation mode, use `{prefix}help Embed` for more info")
-            embeds[ctx.author] = Embed()
+            self.embeds[ctx.author] = Embed()
         else:
             await ctx.send(f":x: {ctx.author.mention} You are already in embed creation mode, use `{prefix}help Embed` for more info")
 
@@ -53,9 +50,9 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embedquit(self, ctx: Context) -> None:
         """Leave embed creation mode"""
-        if ctx.author in embeds:
+        if ctx.author in self.embeds:
             await ctx.send(f"{ctx.author.mention} You are no longer in embed creation mode, your embed was cleared")
-            del embeds[ctx.author]
+            del self.embeds[ctx.author]
         else:
             await ctx.send(f":x: {ctx.author.mention} You aren't in embed mode")
 
@@ -63,21 +60,21 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embedshow(self, ctx: Context) -> None:
         """Take a look at the embed"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        await ctx.send(embed=embeds[ctx.author])
+        await ctx.send(embed=self.embeds[ctx.author])
 
     @command()
     @with_role(*MODERATION_ROLES)
     async def embedsend(self, ctx: Context, channel: TextChannel) -> None:
         """Send the Embed to specified channel"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
         channel_perms = channel.permissions_for(ctx.author)
         if channel_perms.send_messages:
-            embed_msg = await channel.send(embed=embeds[ctx.author])
+            embed_msg = await channel.send(embed=self.embeds[ctx.author])
 
             await self.mod_log.send_log_message(
                 icon_url=Icons.message_edit,
@@ -107,50 +104,50 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_title(self, ctx: Context, *, title: str) -> None:
         """Set embeds title"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].title = title
+        self.embeds[ctx.author].title = title
         await ctx.send("Embeds title updated")
 
     @embed_group.command(name="description")
     @with_role(*MODERATION_ROLES)
     async def embed_description(self, ctx: Context, *, description: str) -> None:
         """Set embeds title"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].description = description
+        self.embeds[ctx.author].description = description
         await ctx.send("Embeds description updated")
 
     @embed_group.command(name="footer")
     @with_role(*MODERATION_ROLES)
     async def embed_footer(self, ctx: Context, *, footer: str) -> None:
         """Set embeds footer"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].set_footer(text=footer)
+        self.embeds[ctx.author].set_footer(text=footer)
         await ctx.send("Embeds footer updated")
 
     @embed_group.command(name="image", aliases=["img"])
     @with_role(*MODERATION_ROLES)
     async def embed_image(self, ctx: Context, *, url: str) -> None:
         """Set embeds image"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].set_image(url=url)
+        self.embeds[ctx.author].set_image(url=url)
         await ctx.send("Embeds Image URL updated")
 
     @embed_group.command(name="color", aliases=["colour"])
     @with_role(*MODERATION_ROLES)
     async def embed_color(self, ctx: Context, *, color: ColourConverter) -> None:
         """Set embeds title, `color` can be HEX color or some of standard colors (red, blue, ...)"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].colour = color
+        self.embeds[ctx.author].colour = color
         await ctx.send("Embeds color updated")
 
     # region: author
@@ -158,10 +155,10 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_author_name(self, ctx: Context, *, author_name: str) -> None:
         """Set authors name in embed"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         embed.set_author(
             name=author_name,
             url=embed.author.url,
@@ -173,10 +170,10 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_author_url(self, ctx: Context, *, author_url: str) -> None:
         """Set authors URL in embed"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         embed.set_author(
             name=embed.author.name,
             url=author_url,
@@ -190,10 +187,10 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_author_icon(self, ctx: Context, *, icon_url: t.Union[FetchedMember, str]) -> None:
         """Set authors icon in embed (You can also mention user to get his avatar)"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         if type(icon_url) != str:
             icon_url = icon_url.avatar_url_as(format="png")
         embed.set_author(
@@ -213,10 +210,10 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_field_create(self, ctx: Context, *, title: str = "None") -> None:
         """Create new field in embed"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
-        embeds[ctx.author].add_field(name=title, value="None")
+        self.embeds[ctx.author].add_field(name=title, value="None")
         self.embed_field_id[ctx.author] += 1
         await ctx.send(f"Embed field with ID **{self.embed_field_id[ctx.author]}** created")
 
@@ -224,13 +221,13 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_field_description(self, ctx: Context, ID: int, *, description: str) -> None:
         """Set description of embeds field"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         embed.set_field_at(
             ID,
             name=embed.fields[ID].name,
@@ -242,13 +239,13 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_field_title(self, ctx: Context, ID: int, *, title: str) -> None:
         """Set title of embeds field"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         embed.set_field_at(
             ID,
             name=title,
@@ -260,14 +257,14 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_field_inline(self, ctx: Context, ID: int, inline: bool) -> None:
         """Choose if embed should be inline or not"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
-        embed = embeds[ctx.author]
+        embed = self.embeds[ctx.author]
         embed.set_field_at(
             ID,
             name=embed.fields[ID].name,
@@ -283,22 +280,21 @@ class Embeds(Cog):
     @with_role(*MODERATION_ROLES)
     async def embed_field_remove(self, ctx: Context, ID: int) -> None:
         """Remove field in embed"""
-        if not await Embeds.has_active_embed(ctx):
+        if not await self.has_active_embed(ctx):
             return
 
         if self.embed_field_id[ctx.author] < ID or ID < 0:
             await ctx.send(f":x: {ctx.author.mention} Sorry, but there is no such field ID")
             return
 
-        embeds[ctx.author].remove_field(ID)
+        self.embeds[ctx.author].remove_field(ID)
         self.embed_field_id[ctx.author] -= 1
         await ctx.send(f"Embed field with ID: **{ID}** removed (all other IDs were renumbered accordingly)")
     # endregion
     # endregion
 
-    @staticmethod
-    async def has_active_embed(ctx):
-        if ctx.author in embeds:
+    async def has_active_embed(self, ctx):
+        if ctx.author in self.embeds:
             return True
         else:
             await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{Bot.prefix}help Embeds`)")

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,37 +1,48 @@
-import asyncio
 import itertools
 import logging
+from asyncio import TimeoutError
 from collections import namedtuple
 from contextlib import suppress
-from typing import Union
+from typing import List, Union
 
-from discord import Colour, Embed, HTTPException, Message, Reaction, User
-from discord.ext import commands
-from discord.ext.commands import CheckFailure
-from discord.ext.commands import Cog as DiscordCog
-from discord.ext.commands import Command, Context
+from discord import Colour, Embed, Member, Message, NotFound, Reaction, User
+from discord.ext.commands import Bot, Cog, Command, Context, Group, HelpCommand
 from fuzzywuzzy import fuzz, process
 
 from bot import constants
-from bot.bot import Bot
-from bot.constants import STAFF_ROLES, Channels, Emojis
+from bot.constants import Channels, Emojis, STAFF_ROLES
 from bot.decorators import redirect_output
-from bot.pagination import (FIRST_EMOJI, LAST_EMOJI, LEFT_EMOJI, RIGHT_EMOJI,
-                            LinePaginator)
-
-DELETE_EMOJI = Emojis.delete
-
-REACTIONS = {
-    FIRST_EMOJI: 'first',
-    LEFT_EMOJI: 'back',
-    RIGHT_EMOJI: 'next',
-    LAST_EMOJI: 'end',
-    DELETE_EMOJI: 'stop',
-}
+from bot.pagination import LinePaginator
 
 log = logging.getLogger(__name__)
 
-Cog = namedtuple('Cog', ['name', 'description', 'commands'])
+COMMANDS_PER_PAGE = 8
+DELETE_EMOJI = Emojis.delete
+PREFIX = constants.Bot.prefix
+
+Category = namedtuple("Category", ["name", "description", "cogs"])
+
+
+async def help_cleanup(bot: Bot, author: Member, message: Message) -> None:
+    """
+    Runs the cleanup for the help command.
+
+    Adds the :trashcan: reaction that, when clicked, will delete the help message.
+    After a 300 second timeout, the reaction will be removed.
+    """
+    def check(reaction: Reaction, user: User) -> bool:
+        """Checks the reaction is :trashcan:, the author is original author and messages are the same."""
+        return str(reaction) == DELETE_EMOJI and user.id == author.id and reaction.message.id == message.id
+
+    await message.add_reaction(DELETE_EMOJI)
+
+    try:
+        await bot.wait_for("reaction_add", check=check, timeout=300)
+        await message.delete()
+    except TimeoutError:
+        await message.remove_reaction(DELETE_EMOJI, bot.user)
+    except NotFound:
+        pass
 
 
 class HelpQueryNotFound(ValueError):
@@ -49,22 +60,9 @@ class HelpQueryNotFound(ValueError):
         self.possible_matches = possible_matches
 
 
-class HelpSession:
+class CustomHelpCommand(HelpCommand):
     """
-    An interactive session for bot and command help output.
-
-    Expected attributes include:
-        * title: str
-            The title of the help message.
-        * query: Union[discord.ext.commands.Bot, discord.ext.commands.Command]
-        * description: str
-            The description of the query.
-        * pages: list[str]
-            A list of the help content split into manageable pages.
-        * message: `discord.Message`
-            The message object that's showing the help contents.
-        * destination: `discord.abc.Messageable`
-            Where the help message is to be sent to.
+    An interactive instance for the bot help command.
 
     Cogs can be grouped into custom categories. All cogs with the same category will be displayed
     under a single category name in the help output. Custom categories are defined inside the cogs
@@ -73,505 +71,313 @@ class HelpSession:
     the regular description (class docstring) of the first cog found in the category.
     """
 
-    def __init__(
-        self,
-        ctx: Context,
-        *command,
-        cleanup: bool = False,
-        only_can_run: bool = True,
-        show_hidden: bool = False,
-        max_lines: int = 15
-    ):
-        """Creates an instance of the HelpSession class."""
-        self._ctx = ctx
-        self._bot = ctx.bot
-        self.title = "Command Help"
+    def __init__(self):
+        super().__init__(command_attrs={"help": "Shows help for bot commands"})
 
-        # set the query details for the session
-        if command:
-            query_str = ' '.join(command)
-            self.query = self._get_query(query_str)
-            self.description = self.query.description or self.query.help
-        else:
-            self.query = ctx.bot
-            self.description = self.query.description
-        self.author = ctx.author
-        self.destination = ctx.channel
-
-        # set the config for the session
-        self._cleanup = cleanup
-        self._only_can_run = only_can_run
-        self._show_hidden = show_hidden
-        self._max_lines = max_lines
-
-        # init session states
-        self._pages = None
-        self._current_page = 0
-        self.message = None
-        self._timeout_task = None
-        self.reset_timeout()
-
-    def _get_query(self, query: str) -> Union[Command, Cog]:
+    @redirect_output(destination_channel=Channels.commands, bypass_roles=STAFF_ROLES)
+    async def command_callback(self, ctx: Context, *, command: str = None) -> None:
         """Attempts to match the provided query with a valid command or cog."""
-        command = self._bot.get_command(query)
-        if command:
-            return command
+        # the only reason we need to tamper with this is because d.py does not support "categories",
+        # so we need to deal with them ourselves.
 
-        # Find all cog categories that match.
+        bot = ctx.bot
+
+        if command is None:
+            # quick and easy, send bot help if command is none
+            mapping = self.get_bot_mapping()
+            await self.send_bot_help(mapping)
+            return
+
         cog_matches = []
         description = None
-        for cog in self._bot.cogs.values():
-            if hasattr(cog, "category") and cog.category == query:
+        for cog in bot.cogs.values():
+            if hasattr(cog, "category") and cog.category == command:
                 cog_matches.append(cog)
                 if hasattr(cog, "category_description"):
                     description = cog.category_description
 
-        # Try to search by cog name if no categories match.
-        if not cog_matches:
-            cog = self._bot.cogs.get(query)
-
-            # Don't consider it a match if the cog has a category.
-            if cog and not hasattr(cog, "category"):
-                cog_matches = [cog]
-
         if cog_matches:
-            cog = cog_matches[0]
-            cmds = (cog.get_commands()
-                    for cog in cog_matches)  # Commands of all cogs
+            category = Category(
+                name=command, description=description, cogs=cog_matches)
+            await self.send_category_help(category)
+            return
 
-            return Cog(
-                name=cog.category if hasattr(
-                    cog, "category") else cog.qualified_name,
-                description=description or cog.description,
-                # Flatten the list
-                commands=tuple(itertools.chain.from_iterable(cmds))
-            )
+        # it's either a cog, group, command or subcommand; let the parent class deal with it
+        await super().command_callback(ctx, command=command)
 
-        self._handle_not_found(query)
-
-    def _handle_not_found(self, query: str) -> None:
+    async def get_all_help_choices(self) -> set:
         """
-        Handles when a query does not match a valid command or cog.
+        Get all the possible options for getting help in the bot.
 
-        Will pass on possible close matches along with the `HelpQueryNotFound` exception.
+        This will only display commands the author has permission to run.
+
+        These include:
+        - Category names
+        - Cog names
+        - Group command names (and aliases)
+        - Command names (and aliases)
+        - Subcommand names (with parent group and aliases for subcommand, but not including aliases for group)
+
+        Options and choices are case sensitive.
         """
-        # Combine command and cog names
-        choices = list(self._bot.all_commands) + list(self._bot.cogs)
+        # first get all commands including subcommands and full command name aliases
+        choices = set()
+        for command in await self.filter_commands(self.context.bot.walk_commands()):
+            # the the command or group name
+            choices.add(str(command))
 
+            if isinstance(command, Command):
+                # all aliases if it's just a command
+                choices.update(command.aliases)
+            else:
+                # otherwise we need to add the parent name in
+                choices.update(
+                    f"{command.full_parent_name} {alias}" for alias in command.aliases)
+
+        # all cog names
+        choices.update(self.context.bot.cogs)
+
+        # all category names
+        choices.update(cog.category for cog in self.context.bot.cogs.values(
+        ) if hasattr(cog, "category"))
+        return choices
+
+    async def command_not_found(self, string: str) -> "HelpQueryNotFound":
+        """
+        Handles when a query does not match a valid command, group, cog or category.
+
+        Will return an instance of the `HelpQueryNotFound` exception with the error message and possible matches.
+        """
+        choices = await self.get_all_help_choices()
         result = process.extractBests(
-            query, choices, scorer=fuzz.ratio, score_cutoff=90)
+            string, choices, scorer=fuzz.ratio, score_cutoff=60)
 
-        raise HelpQueryNotFound(f'Query "{query}" not found.', dict(result))
+        return HelpQueryNotFound(f'Query "{string}" not found.', dict(result))
 
-    async def timeout(self, seconds: int = 30) -> None:
-        """Waits for a set number of seconds, then stops the help session."""
-        await asyncio.sleep(seconds)
-        await self.stop()
+    async def subcommand_not_found(self, command: Command, string: str) -> "HelpQueryNotFound":
+        """
+        Redirects the error to `command_not_found`.
 
-    def reset_timeout(self) -> None:
-        """Cancels the original timeout task and sets it again from the start."""
-        # cancel original if it exists
-        if self._timeout_task:
-            if not self._timeout_task.cancelled():
-                self._timeout_task.cancel()
+        `command_not_found` deals with searching and getting best choices for both commands and subcommands.
+        """
+        return await self.command_not_found(f"{command.qualified_name} {string}")
 
-        # recreate the timeout task
-        self._timeout_task = self._bot.loop.create_task(self.timeout())
+    async def send_error_message(self, error: HelpQueryNotFound) -> None:
+        """Send the error message to the channel."""
+        embed = Embed(colour=Colour.red(), title=str(error))
 
-    async def on_reaction_add(self, reaction: Reaction, user: User) -> None:
-        """Event handler for when reactions are added on the help message."""
-        # ensure it was the relevant session message
-        if reaction.message.id != self.message.id:
-            return
+        if getattr(error, "possible_matches", None):
+            matches = "\n".join(
+                f"`{match}`" for match in error.possible_matches)
+            embed.description = f"**Did you mean:**\n{matches}"
 
-        # ensure it was the session author who reacted
-        if user.id != self.author.id:
-            return
+        await self.context.send(embed=embed)
 
-        emoji = str(reaction.emoji)
+    async def command_formatting(self, command: Command) -> Embed:
+        """
+        Takes a command and turns it into an embed.
 
-        # check if valid action
-        if emoji not in REACTIONS:
-            return
+        It will add an author, command signature + help, aliases and a note if the user can't run the command.
+        """
+        embed = Embed()
+        embed.set_author(name="Command Help",
+                         icon_url=constants.Icons.questionmark)
 
-        self.reset_timeout()
+        parent = command.full_parent_name
 
-        # Run relevant action method
-        action = getattr(self, f'do_{REACTIONS[emoji]}', None)
-        if action:
-            await action()
+        name = str(command) if not parent else f"{parent} {command.name}"
+        command_details = f"**```{PREFIX}{name} {command.signature}```**\n"
 
-        # remove the added reaction to prep for re-use
-        with suppress(HTTPException):
-            await self.message.remove_reaction(reaction, user)
+        # show command aliases
+        aliases = ", ".join(
+            f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases)
+        if aliases:
+            command_details += f"**Can also use:** {aliases}\n\n"
 
-    async def on_message_delete(self, message: Message) -> None:
-        """Closes the help session when the help message is deleted."""
-        if message.id == self.message.id:
-            await self.stop()
+        # check if the user is allowed to run this command
+        if not await command.can_run(self.context):
+            command_details += "***You cannot run this command.***\n\n"
 
-    async def prepare(self) -> None:
-        """Sets up the help session pages, events, message and reactions."""
-        # create paginated content
-        await self.build_pages()
+        command_details += f"*{command.help or 'No details provided.'}*\n"
+        embed.description = command_details
 
-        # setup listeners
-        self._bot.add_listener(self.on_reaction_add)
-        self._bot.add_listener(self.on_message_delete)
+        return embed
 
-        # Send the help message
-        await self.update_page()
-        self.add_reactions()
+    async def send_command_help(self, command: Command) -> None:
+        """Send help for a single command."""
+        embed = await self.command_formatting(command)
+        message = await self.context.send(embed=embed)
+        await help_cleanup(self.context.bot, self.context.author, message)
 
-    def add_reactions(self) -> None:
-        """Adds the relevant reactions to the help message based on if pagination is required."""
-        # if paginating
-        if len(self._pages) > 1:
-            for reaction in REACTIONS:
-                self._bot.loop.create_task(self.message.add_reaction(reaction))
+    @staticmethod
+    def get_commands_brief_details(commands_: List[Command], return_as_list: bool = False) -> Union[List[str], str]:
+        """
+        Formats the prefix, command name and signature, and short doc for an iterable of commands.
 
-        # if single-page
+        return_as_list is helpful for passing these command details into the paginator as a list of command details.
+        """
+        details = []
+        for command in commands_:
+            signature = f" {command.signature}" if command.signature else ""
+            details.append(
+                f"\n**`{PREFIX}{command.qualified_name}{signature}`**\n*{command.short_doc or 'No details provided'}*"
+            )
+        if return_as_list:
+            return details
         else:
-            self._bot.loop.create_task(self.message.add_reaction(DELETE_EMOJI))
+            return "".join(details)
 
-    def _category_key(self, cmd: Command) -> str:
+    async def send_group_help(self, group: Group) -> None:
+        """Sends help for a group command."""
+        subcommands = group.commands
+
+        if len(subcommands) == 0:
+            # no subcommands, just treat it like a regular command
+            await self.send_command_help(group)
+            return
+
+        # remove commands that the user can't run and are hidden, and sort by name
+        commands_ = await self.filter_commands(subcommands, sort=True)
+
+        embed = await self.command_formatting(group)
+
+        command_details = self.get_commands_brief_details(commands_)
+        if command_details:
+            embed.description += f"\n**Subcommands:**\n{command_details}"
+
+        message = await self.context.send(embed=embed)
+        await help_cleanup(self.context.bot, self.context.author, message)
+
+    async def send_cog_help(self, cog: Cog) -> None:
+        """Send help for a cog."""
+        # sort commands by name, and remove any the user cant run or are hidden.
+        commands_ = await self.filter_commands(cog.get_commands(), sort=True)
+
+        embed = Embed()
+        embed.set_author(name="Command Help",
+                         icon_url=constants.Icons.questionmark)
+        embed.description = f"**{cog.qualified_name}**\n*{cog.description}*"
+
+        command_details = self.get_commands_brief_details(commands_)
+        if command_details:
+            embed.description += f"\n\n**Commands:**\n{command_details}"
+
+        message = await self.context.send(embed=embed)
+        await help_cleanup(self.context.bot, self.context.author, message)
+
+    @staticmethod
+    def _category_key(command: Command) -> str:
         """
         Returns a cog name of a given command for use as a key for `sorted` and `groupby`.
 
         A zero width space is used as a prefix for results with no cogs to force them last in ordering.
         """
-        if cmd.cog:
-            try:
-                if cmd.cog.category:
-                    return f'**{cmd.cog.category}**'
-            except AttributeError:
-                pass
-
-            return f'**{cmd.cog_name}**'
+        if command.cog:
+            with suppress(AttributeError):
+                if command.cog.category:
+                    return f"**{command.cog.category}**"
+            return f"**{command.cog_name}**"
         else:
             return "**\u200bNo Category:**"
 
-    def _get_command_params(self, cmd: Command) -> str:
+    async def send_category_help(self, category: Category) -> None:
         """
-        Returns the command usage signature.
+        Sends help for a bot category.
 
-        This is a custom implementation of `command.signature` in order to format the command
-        signature without aliases.
+        This sends a brief help for all commands in all cogs registered to the category.
         """
-        results = []
-        for name, param in cmd.clean_params.items():
-
-            # if argument has a default value
-            if param.default is not param.empty:
-
-                if isinstance(param.default, str):
-                    show_default = param.default
-                else:
-                    show_default = param.default is not None
-
-                # if default is not an empty string or None
-                if show_default:
-                    results.append(f'[{name}={param.default}]')
-                else:
-                    results.append(f'[{name}]')
-
-            # if variable length argument
-            elif param.kind == param.VAR_POSITIONAL:
-                results.append(f'[{name}...]')
-
-            # if required
-            else:
-                results.append(f'<{name}>')
-
-        return f"{cmd.name} {' '.join(results)}"
-
-    async def build_pages(self) -> None:
-        """Builds the list of content pages to be paginated through in the help message, as a list of str."""
-        # Use LinePaginator to restrict embed line height
-        paginator = LinePaginator(
-            prefix='', suffix='', max_lines=self._max_lines)
-
-        prefix = constants.Bot.prefix
-
-        # show signature if query is a command
-        if isinstance(self.query, commands.Command):
-            signature = self._get_command_params(self.query)
-            parent = self.query.full_parent_name + ' ' if self.query.parent else ''
-            paginator.add_line(f'**```{prefix}{parent}{signature}```**')
-
-            # show command aliases
-            aliases = ', '.join(f'`{a}`' for a in self.query.aliases)
-            if aliases:
-                paginator.add_line(f'**Can also use:** {aliases}\n')
-
-            if not await self.query.can_run(self._ctx):
-                paginator.add_line('***You cannot run this command.***\n')
-
-        # show name if query is a cog
-        if isinstance(self.query, Cog):
-            paginator.add_line(f'**{self.query.name}**')
-
-        if self.description:
-            paginator.add_line(f'*{self.description}*')
-
-        # list all children commands of the queried object
-        if isinstance(self.query, (commands.GroupMixin, Cog)):
-
-            # remove hidden commands if session is not wanting hiddens
-            if not self._show_hidden:
-                filtered = [c for c in self.query.commands if not c.hidden]
-            else:
-                filtered = self.query.commands
-
-            # if after filter there are no commands, finish up
-            if not filtered:
-                self._pages = paginator.pages
-                return
-
-            # set category to Commands if cog
-            if isinstance(self.query, Cog):
-                grouped = (('**Commands:**', self.query.commands),)
-
-            # set category to Subcommands if command
-            elif isinstance(self.query, commands.Command):
-                grouped = (('**Subcommands:**', self.query.commands),)
-
-                # don't show prefix for subcommands
-                prefix = ''
-
-            # otherwise sort and organise all commands into categories
-            else:
-                cat_sort = sorted(filtered, key=self._category_key)
-                grouped = itertools.groupby(cat_sort, key=self._category_key)
-
-            # process each category
-            for category, cmds in grouped:
-                cmds = sorted(cmds, key=lambda c: c.name)
-
-                # if there are no commands, skip category
-                if len(cmds) == 0:
-                    continue
-
-                cat_cmds = []
-
-                # format details for each child command
-                for command in cmds:
-
-                    # skip if hidden and hide if session is set to
-                    if command.hidden and not self._show_hidden:
-                        continue
-
-                    # see if the user can run the command
-                    strikeout = ''
-
-                    # Patch to make the !help command work outside of #bot-commands again
-                    # This probably needs a proper rewrite, but this will make it work in
-                    # the mean time.
-                    try:
-                        can_run = await command.can_run(self._ctx)
-                    except CheckFailure:
-                        can_run = False
-
-                    if not can_run:
-                        # skip if we don't show commands they can't run
-                        if self._only_can_run:
-                            continue
-                        strikeout = '~~'
-
-                    signature = self._get_command_params(command)
-                    info = f"{strikeout}**`{prefix}{signature}`**{strikeout}"
-
-                    # handle if the command has no docstring
-                    if command.short_doc:
-                        cat_cmds.append(f'{info}\n*{command.short_doc}*')
-                    else:
-                        cat_cmds.append(f'{info}\n*No details provided.*')
-
-                # state var for if the category should be added next
-                print_cat = 1
-                new_page = True
-
-                for details in cat_cmds:
-
-                    # keep details together, paginating early if it won't fit
-                    lines_adding = len(details.split('\n')) + print_cat
-                    if paginator._linecount + lines_adding > self._max_lines:
-                        paginator._linecount = 0
-                        new_page = True
-                        paginator.close_page()
-
-                        # new page so print category title again
-                        print_cat = 1
-
-                    if print_cat:
-                        if new_page:
-                            paginator.add_line('')
-                        paginator.add_line(category)
-                        print_cat = 0
-
-                    paginator.add_line(details)
-
-        # save organized pages to session
-        self._pages = paginator.pages
-
-    def embed_page(self, page_number: int = 0) -> Embed:
-        """Returns an Embed with the requested page formatted within."""
         embed = Embed()
+        embed.set_author(name="Command Help",
+                         icon_url=constants.Icons.questionmark)
 
-        # if command or cog, add query to title for pages other than first
-        if isinstance(self.query, (commands.Command, Cog)) and page_number > 0:
-            title = f'Command Help | "{self.query.name}"'
-        else:
-            title = self.title
+        all_commands = []
+        for cog in category.cogs:
+            all_commands.extend(cog.get_commands())
 
-        embed.set_author(name=title, icon_url=constants.Icons.questionmark)
-        embed.description = self._pages[page_number]
+        filtered_commands = await self.filter_commands(all_commands, sort=True)
 
-        # add page counter to footer if paginating
-        page_count = len(self._pages)
-        if page_count > 1:
-            embed.set_footer(
-                text=f'Page {self._current_page+1} / {page_count}')
+        command_detail_lines = self.get_commands_brief_details(
+            filtered_commands, return_as_list=True)
+        description = f"**{category.name}**\n*{category.description}*"
 
-        return embed
+        if command_detail_lines:
+            description += "\n\n**Commands:**"
 
-    async def update_page(self, page_number: int = 0) -> None:
-        """Sends the initial message, or changes the existing one to the given page number."""
-        self._current_page = page_number
-        embed_page = self.embed_page(page_number)
+        await LinePaginator.paginate(
+            command_detail_lines,
+            self.context,
+            embed,
+            prefix=description,
+            max_lines=COMMANDS_PER_PAGE,
+            max_size=2040,
+        )
 
-        if not self.message:
-            self.message = await self.destination.send(embed=embed_page)
-        else:
-            await self.message.edit(embed=embed_page)
+    async def send_bot_help(self, mapping: dict) -> None:
+        """Sends help for all bot commands and cogs."""
+        bot = self.context.bot
 
-    @classmethod
-    async def start(cls, ctx: Context, *command, **options) -> "HelpSession":
-        """
-        Create and begin a help session based on the given command context.
+        embed = Embed()
+        embed.set_author(name="Command Help",
+                         icon_url=constants.Icons.questionmark)
 
-        Available options kwargs:
-            * cleanup: Optional[bool]
-                Set to `True` to have the message deleted on session end. Defaults to `False`.
-            * only_can_run: Optional[bool]
-                Set to `True` to hide commands the user can't run. Defaults to `False`.
-            * show_hidden: Optional[bool]
-                Set to `True` to include hidden commands. Defaults to `False`.
-            * max_lines: Optional[int]
-                Sets the max number of lines the paginator will add to a single page. Defaults to 20.
-        """
-        session = cls(ctx, *command, **options)
-        await session.prepare()
+        filter_commands = await self.filter_commands(bot.commands, sort=True, key=self._category_key)
 
-        return session
+        cog_or_category_pages = []
 
-    async def stop(self) -> None:
-        """Stops the help session, removes event listeners and attempts to delete the help message."""
-        self._bot.remove_listener(self.on_reaction_add)
-        self._bot.remove_listener(self.on_message_delete)
+        for cog_or_category, _commands in itertools.groupby(filter_commands, key=self._category_key):
+            sorted_commands = sorted(_commands, key=lambda c: c.name)
 
-        # ignore if permission issue, or the message doesn't exist
-        with suppress(HTTPException, AttributeError):
-            if self._cleanup:
-                await self.message.delete()
+            if len(sorted_commands) == 0:
+                continue
+
+            command_detail_lines = self.get_commands_brief_details(
+                sorted_commands, return_as_list=True)
+
+            # Split cogs or categories which have too many commands to fit in one page.
+            # The length of commands is included for later use when aggregating into pages for the paginator.
+            for index in range(0, len(sorted_commands), COMMANDS_PER_PAGE):
+                truncated_lines = command_detail_lines[index:index +
+                                                       COMMANDS_PER_PAGE]
+                joined_lines = "".join(truncated_lines)
+                cog_or_category_pages.append(
+                    (f"**{cog_or_category}**{joined_lines}", len(truncated_lines)))
+
+        pages = []
+        counter = 0
+        page = ""
+        for page_details, length in cog_or_category_pages:
+            counter += length
+            if counter > COMMANDS_PER_PAGE:
+                # force a new page on paginator even if it falls short of the max pages
+                # since we still want to group categories/cogs.
+                counter = length
+                pages.append(page)
+                page = f"{page_details}\n\n"
             else:
-                await self.message.clear_reactions()
+                page += f"{page_details}\n\n"
 
-    @property
-    def is_first_page(self) -> bool:
-        """Check if session is currently showing the first page."""
-        return self._current_page == 0
+        if page:
+            # add any remaining command help that didn't get added in the last iteration above.
+            pages.append(page)
 
-    @property
-    def is_last_page(self) -> bool:
-        """Check if the session is currently showing the last page."""
-        return self._current_page == (len(self._pages) - 1)
-
-    async def do_first(self) -> None:
-        """Event that is called when the user requests the first page."""
-        if not self.is_first_page:
-            await self.update_page(0)
-
-    async def do_back(self) -> None:
-        """Event that is called when the user requests the previous page."""
-        if not self.is_first_page:
-            await self.update_page(self._current_page - 1)
-
-    async def do_next(self) -> None:
-        """Event that is called when the user requests the next page."""
-        if not self.is_last_page:
-            await self.update_page(self._current_page + 1)
-
-    async def do_end(self) -> None:
-        """Event that is called when the user requests the last page."""
-        if not self.is_last_page:
-            await self.update_page(len(self._pages) - 1)
-
-    async def do_stop(self) -> None:
-        """Event that is called when the user requests to stop the help session."""
-        await self.message.delete()
+        await LinePaginator.paginate(pages, self.context, embed=embed, max_lines=1, max_size=2040)
 
 
-class Help(DiscordCog):
+class Help(Cog):
     """Custom Embed Pagination Help feature."""
 
-    @commands.command('help')
-    @redirect_output(destination_channel=Channels.commands, bypass_roles=STAFF_ROLES)
-    async def new_help(self, ctx: Context, *commands) -> None:
-        """Shows Command Help."""
-        try:
-            await HelpSession.start(ctx, *commands)
-        except HelpQueryNotFound as error:
-            embed = Embed()
-            embed.colour = Colour.red()
-            embed.title = str(error)
+    def __init__(self, bot: Bot) -> None:
+        self.bot = bot
+        self.old_help_command = bot.help_command
+        bot.help_command = CustomHelpCommand()
+        bot.help_command.cog = self
 
-            if error.possible_matches:
-                matches = '\n'.join(error.possible_matches.keys())
-                embed.description = f'**Did you mean:**\n`{matches}`'
-
-            await ctx.send(embed=embed)
-
-
-def unload(bot: Bot) -> None:
-    """
-    Reinstates the original help command.
-
-    This is run if the cog raises an exception on load, or if the extension is unloaded.
-    """
-    bot.remove_command('help')
-    bot.add_command(bot._old_help)
+    def cog_unload(self) -> None:
+        """Reset the help command when the cog is unloaded."""
+        self.bot.help_command = self.old_help_command
 
 
 def setup(bot: Bot) -> None:
-    """
-    The setup for the help extension.
-
-    This is called automatically on `bot.load_extension` being run.
-
-    Stores the original help command instance on the `bot._old_help` attribute for later
-    reinstatement, before removing it from the command registry so the new help command can be
-    loaded successfully.
-
-    If an exception is raised during the loading of the cog, `unload` will be called in order to
-    reinstate the original help command.
-    """
-    bot._old_help = bot.get_command('help')
-    bot.remove_command('help')
-
-    try:
-        bot.add_cog(Help())
-    except Exception:
-        unload(bot)
-        raise
-
-
-def teardown(bot: Bot) -> None:
-    """
-    The teardown for the help extension.
-
-    This is called automatically on `bot.unload_extension` being run.
-
-    Calls `unload` in order to reinstate the original help command.
-    """
-    unload(bot)
+    """Load the Help cog."""
+    bot.add_cog(Help(bot))
+    log.info("Cog loaded: Help")

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -11,7 +11,7 @@ from discord.errors import NotFound
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Cog, Context
 
-from bot.constants import ERROR_REPLIES, Bot, RedirectOutput
+from bot.constants import ERROR_REPLIES, RedirectOutput
 from bot.utils.checks import with_role_check, without_role_check
 
 log = logging.getLogger(__name__)
@@ -226,14 +226,3 @@ def respect_role_hierarchy(target_arg: Union[int, str] = 0) -> Callable:
                 await func(self, ctx, *args, **kwargs)
         return inner
     return wrap
-
-
-def has_active_embed(embeds: dict) -> Callable:
-    """Make sure that the author has an active embed in the `embeds` dict"""
-    async def predicate(ctx) -> bool:
-        if ctx.author in embeds:
-            return True
-        else:
-            await ctx.send(f":x: {ctx.author.mention} No active embed found, are you in embed building mode? (`{Bot.prefix}help Embeds`)")
-            return False
-    return commands.check(predicate)

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from asyncio import Lock, sleep
+from asyncio import Lock, create_task, sleep
 from contextlib import suppress
 from functools import wraps
 from typing import Callable, Container, Union
@@ -155,7 +155,7 @@ def redirect_output(destination_channel: int, bypass_roles: Container[int] = Non
                 f"Redirecting output of {ctx.author}'s command '{ctx.command.name}' to {redirect_channel.name}")
             ctx.channel = redirect_channel
             await ctx.channel.send(f"Here's the output of your command, {ctx.author.mention}")
-            await func(self, ctx, *args, **kwargs)
+            create_task(func(self, ctx, *args, **kwargs))
 
             message = await old_channel.send(
                 f"Hey, {ctx.author.mention}, you can find the output of your command here: "


### PR DESCRIPTION
Closes #11 

There is a built-in way to get help from Discord.py
This means instead of fully writing out our help function, we can simply use this new built-in way and build our system on top of it.

* The help command has been refactored to subclass `commands.HelpCommand`. This means that it now supports methods such as `ctx.send_help(ctx.command)`.

* `redirect_output` has been adjusted to use `asyncio.create_task`

* `help_cleanup` provides the opportunity to use the :x:  reaction to cleanup help even with no pagination.

* Pagination purely happens through the `LinePaginator`, forcing a pagination session with 1 line per page where we format the page style before sending it through.

* Categories are properly dealt with by finding a match and sending a separate help where a named tuple of the Category name, description, and relevant cogs is the only parameter.

* Choices for when a command was not found has been updated to include category names, cog names, aliases of group and command names, and include all subcommands and aliases. This should provide a more helpful output when an error message is sent

* Sending command, group, cog, category, and bot help has been split into different functions that are called from `command_callback`. This provides an easier way to alter future changes, and cleans up code considerably.

* Unfortunately this brings an issue with the embeds cog which was using `@has_active_embed` decorator, which is not compatible with this new help system, which means it was not rewritten and used only as if statement in each of the functions which used this decorator