### PR TITLE
Use selector event loop on Windows

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import os
 import sys
 from logging import handlers
 from pathlib import Path
@@ -46,3 +48,7 @@ logging.getLogger('bot.utils.scheduling').setLevel(logging.INFO)
 logging.getLogger('bot.decorators').setLevel(logging.INFO)
 
 logging.getLogger(__name__)
+
+# On Windows, the selector event loop is required for aiodns.
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
Closes #24 

In Python 3.8, the default event loop for Windows was changed to proactor. To fix this, the event loop is explicitly set to selector.