### PR TITLE
Rework `in_channel` decorator

### DIFF
--- a/bot/cogs/announcements.py
+++ b/bot/cogs/announcements.py
@@ -7,7 +7,7 @@ from bot.bot import Bot
 from bot.constants import STAFF_ROLES
 from bot.constants import Bot as BotConstant
 from bot.constants import Channels, Roles
-from bot.decorators import in_channel
+from bot.decorators import in_whitelist
 from bot.utils.checks import with_role_check, without_role_check
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ class Announcements(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @in_channel(Channels.commands, bypass_roles=STAFF_ROLES)
+    @in_whitelist(redirect=Channels.commands, roles=STAFF_ROLES)
     @command()
     async def subscribe(self, ctx: Context) -> None:
         """Get notified on new announcements"""
@@ -31,7 +31,7 @@ class Announcements(commands.Cog):
         else:
             await ctx.send(f'You are already subscribed (use {BotConstant.prefix}unsubscribe to unsubscribe)')
 
-    @in_channel(Channels.commands, bypass_roles=STAFF_ROLES)
+    @in_whitelist(redirect=Channels.commands, roles=STAFF_ROLES)
     @command()
     async def unsubscribe(self, ctx: Context) -> None:
         """Stop receiving new announcements"""

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -5,7 +5,7 @@ from discord.ext.commands import Cog, Command, Context, errors
 from sentry_sdk import push_scope
 
 from bot.bot import Bot
-from bot.decorators import InChannelCheckFailure, PermissionCheckFailure
+from bot.decorators import InWhitelistCheckFailure, PermissionCheckFailure
 
 log = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ class ErrorHandler(Cog):
         * BotMissingRole
         * BotMissingAnyRole
         * NoPrivateMessage
-        * InChannelCheckFailure
+        * InWhitelistCheckFailure
         * PermissionCheckFailure
         """
         bot_missing_errors = (
@@ -140,7 +140,7 @@ class ErrorHandler(Cog):
         )
 
         user_errors = (
-            InChannelCheckFailure,
+            InWhitelistCheckFailure,
             PermissionCheckFailure,
             errors.NoPrivateMessage
         )

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -13,7 +13,7 @@ from discord.utils import escape_markdown
 import bot.utils.infractions as infractions
 from bot import constants
 from bot.bot import Bot
-from bot.decorators import InChannelCheckFailure, with_role
+from bot.decorators import with_role, in_whitelist
 from bot.pagination import LinePaginator
 from bot.utils.checks import has_higher_role_check, with_role_check
 from bot.utils.converters import FetchedMember
@@ -145,6 +145,7 @@ class Information(Cog):
 
         await ctx.send(embed=embed)
 
+    @in_whitelist(redirect=constants.Channels.commands, roles=constants.STAFF_ROLES)
     @command(name="user", aliases=["user_info", "member", "member_info"])
     async def user_info(self, ctx: Context, user: FetchedMember = None) -> None:
         """Returns info about a user."""
@@ -156,15 +157,11 @@ class Information(Cog):
             await ctx.send("You may not use this command on users other than yourself.")
             return
 
-        # Non-staff may only do this in #bot-commands
-        if not with_role_check(ctx, *constants.STAFF_ROLES):
-            if not ctx.channel.id == constants.Channels.commands:
-                raise InChannelCheckFailure(constants.Channels.commands)
-
         embed = await self.create_user_embed(ctx, user)
 
         await ctx.send(embed=embed)
 
+    @in_whitelist(redirect=constants.Channels.commands, roles=constants.STAFF_ROLES)
     @command(name="infractions", aliases=["show_infractions"])
     async def infractions(self, ctx: Context, user: FetchedMember = None) -> None:
         '''Return user's infractions'''
@@ -188,11 +185,6 @@ class Information(Cog):
             )
             await ctx.send(embed=embed)
             return
-
-        # Non-staff may only do this in #bot-commands
-        if not with_role_check(ctx, *constants.STAFF_ROLES):
-            if not ctx.channel.id == constants.Channels.commands:
-                raise InChannelCheckFailure(constants.Channels.commands)
 
         embed = await self.create_infractions_embed(ctx, user)
 

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -3,7 +3,7 @@ import random
 from asyncio import Lock, create_task, sleep
 from contextlib import suppress
 from functools import wraps
-from typing import Callable, Container, Union
+from typing import Callable, Container, Optional, Union
 from weakref import WeakValueDictionary
 
 from discord import Colour, Embed, Member
@@ -11,21 +11,26 @@ from discord.errors import NotFound
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Cog, Context
 
-from bot.constants import ERROR_REPLIES, RedirectOutput
+from bot.constants import ERROR_REPLIES, Channels, RedirectOutput
 from bot.utils.checks import with_role_check, without_role_check
 
 log = logging.getLogger(__name__)
 
 
-class InChannelCheckFailure(CheckFailure):
+class InWhitelistCheckFailure(CheckFailure):
     """Raised when a check fails for a message being sent in a whitelisted channel."""
 
-    def __init__(self, *channels: int):
-        self.channels = channels
-        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)
+    def __init__(self, redirect_channel: Optional[int]):
+        self.redirect_channel = redirect_channel
 
-        super().__init__(
-            f"Sorry, but you may only use this command within {channels_str}.")
+        if redirect_channel:
+            redirect_message = f" here. Please use the <#{redirect_channel}> channel instead"
+        else:
+            redirect_message = ""
+
+        error_message = f"You are not allowed to use that command{redirect_message}."
+
+        super().__init__(error_message)
 
 
 class PermissionCheckFailure(CheckFailure):
@@ -38,38 +43,60 @@ class PermissionCheckFailure(CheckFailure):
             f"Sorry, but you don't have permission to use {self.command} command.")
 
 
-def in_channel(
-    *channels: int,
-    hidden_channels: Container[int] = None,
-    bypass_roles: Container[int] = None
+def in_whitelist(
+    *,
+    channels: Container[int] = (),
+    categories: Container[int] = (),
+    roles: Container[int] = (),
+    redirect: Optional[int] = Channels.commands
 ) -> Callable:
     """
-    Checks that the message is in a whitelisted channel or optionally has a bypass role.
+    Check if a command was issued in a whitelisted context.
 
-    Hidden channels are channels which will not be displayed in the InChannelCheckFailure error
-    message.
+    The whitelists that can be provided are:
+
+    - `channels`: a container with channel ids for whitelisted channels
+    - `categories`: a container with category ids for whitelisted categories
+    - `roles`: a container with with role ids for whitelisted roles
+
+    If the command was invoked in a context that was not whitelisted, the member is either
+    redirected to the `redirect` channel that was passed (default: #bot-commands) or simply
+    told that they're not allowed to use this particular command (if `None` was passed).
     """
-    hidden_channels = hidden_channels or []
-    bypass_roles = bypass_roles or []
+    if redirect and redirect not in channels:
+        # It does not make sense for the channel whitelist to not contain the redirection
+        # channel (if applicable). That's why we add the redirection channel to the `channels`
+        # container if it's not already in it. As we allow any container type to be passed,
+        # we first create a tuple in order to safely add the redirection channel.
+        #
+        # Note: It's possible for the redirect channel to be in a whitelisted category, but
+        # there's no easy way to check that and as a channel can easily be moved in and out of
+        # categories, it's probably not wise to rely on its category in any case.
+        channels = tuple(channels) + (redirect, )
 
     def predicate(ctx: Context) -> bool:
-        """In-channel checker predicate."""
-        if ctx.channel.id in channels or ctx.channel.id in hidden_channels:
-            log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                      f"The command was used in a whitelisted channel.")
+        """Check if a command was issued in a whitelisted context."""
+        if channels and ctx.channel.id in channels:
+            log.debug(
+                f"{ctx.author} may use the `{ctx.command.name}` command as they are in a whitelisted channel")
             return True
 
-        if bypass_roles:
-            if any(r.id in bypass_roles for r in ctx.author.roles):
-                log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                          f"The command was not used in a whitelisted channel, "
-                          f"but the author had a role to bypass the in_channel check.")
-                return True
+        # Only check the category id if we have a category whitelist and the channel has a `category_id`
+        if categories and hasattr(ctx.channel, "category_id") and ctx.channel.category_id in categories:
+            log.debug(
+                f"{ctx.author} may use the `{ctx.command.name}` command as they are in a whitelisted category.")
+            return True
 
-        log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                  f"The in_channel check failed.")
+        # Only check the roles whitelist if we have one and ensure the author's roles attribute returns
+        # on iterable to prevent breakage in DM channels (for if we ever decide to enable commands there).
+        if roles and any(r.id in roles for r in getattr(ctx.author, "roles", ())):
+            log.debug(
+                f"{ctx.author} may use `{ctx.command.name}` command as they have a whitelisted role")
+            return True
 
-        raise InChannelCheckFailure(*channels)
+        log.debug(
+            f"{ctx.author} may not use the `{ctx.command.name}` command within this context.")
+        raise InWhitelistCheckFailure(redirect)
 
     return commands.check(predicate)
 


### PR DESCRIPTION
Closes #27 

As suggested in #27 decorator `in_channel` was reworked and changed to `in_whitelist`.
The exception `InChannelCheckFailure` was also renamed to `InWhitelistCheckFailure`.

Added all suggested features from the corresponding issue.