### PR TITLE
Add handy scripts to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,5 +23,8 @@ coverage = "*"
 python_version = "3.8"
 
 [scripts]
+start = "python -m bot"
+lint = "pre-commit run --all-files"
+precommit = "pre-commit install"
 test = "coverage run -m unittest"
 report = "coverage report"

--- a/commandbot.service
+++ b/commandbot.service
@@ -7,7 +7,7 @@ WorkingDirectory=/home/koumakpet/CommandBot
 
 Restart=on-failure
 
-ExecStart=/usr/bin/screen -DmS CommandBot pipenv run python start.py
+ExecStart=/usr/bin/screen -DmS CommandBot pipenv run start
 
 [Install]
 WantedBy=multi-user.target

--- a/start.py
+++ b/start.py
@@ -1,4 +1,0 @@
-from bot import __main__ as main
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
Closes #21 

Add some "scripts" (aliases) to Pipfile for ease of use:
- `pipenv run start` for easier starting of the bot
- `pipenv run lint` to run full pre-commit check on all files
- `pipenv run precommit` to install pre-commit

Already added scripts from #17 (Unit Tests):
- `pipenv run test` to run all unittests
- `pipenv run report` to show coverage report of the unittests