### PR TITLE
Channel mutes

### DIFF
--- a/bot/cogs/moderation/__init__.py
+++ b/bot/cogs/moderation/__init__.py
@@ -1,8 +1,10 @@
 from .infractions import Infractions
 from .modlog import ModLog
+from .silence import Silence
 
 
 def setup(bot) -> None:
     '''Load the moderation cogs.'''
     bot.add_cog(ModLog(bot))
     bot.add_cog(Infractions(bot))
+    bot.add_cog(Silence(bot))

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -85,6 +85,12 @@ class Silence(commands.Cog):
 
         Duration is capped at 15 minutes for non-moderators.
         """
+        if not ctx.channel.permissions_for(ctx.author).manage_messages:
+            await ctx.send(
+                f"{Emojis.cross_mark} sorry, you can't manage messages here")
+            log.debug(
+                f"{ctx.author} tried to silence #{ctx.channel} without manage messages permission")
+            return
         await self._get_instance_vars_event.wait()
         log.debug(f"{ctx.author} is silencing channel #{ctx.channel}")
 
@@ -122,6 +128,13 @@ class Silence(commands.Cog):
     @commands.command(aliases=("unhush", "unmutechat"))
     async def unsilence(self, ctx: Context) -> None:
         """Unsiilence the current channel."""
+        if not ctx.channel.permissions_for(ctx.author).manage_messages:
+            await ctx.send(
+                f"{Emojis.cross_mark} sorry, you can't manage messages here")
+            log.debug(
+                f"{ctx.author} tried to unsilence #{ctx.channel} without manage messages permission")
+            return
+
         await self._get_instance_vars_event.wait()
         log.debug(
             f"Unsilencing channel #{ctx.channel} from {ctx.author}'s command.")

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -34,9 +34,7 @@ class UnsilenceScheduler(Scheduler):
     async def schedule_unsilence(self, channel: SilencedChannel) -> None:
         """Schedule expiration for silenced channels"""
         await self.bot.wait_until_guild_available()
-
         log.debug("Scheduling unsilencer")
-
         self.schedule_task(channel.id, channel)
 
     async def _scheduled_task(self, channel: SilencedChannel) -> None:

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -1,0 +1,102 @@
+import asyncio
+import logging
+from typing import Optional
+
+from discord import TextChannel
+from discord.ext import commands
+from discord.ext.commands import Context
+
+from bot.bot import Bot
+from bot.constants import STAFF_ROLES, Channels, Emojis, Guild, Roles
+from bot.converters import SilenceDurationConverter
+from bot.utils.checks import with_role_check
+
+log = logging.getLogger(__name__)
+
+
+class Silence(commands.Cog):
+    """Commands for stopping channel messages for `Guest` role in a channel."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.muted_channels = set()
+        self._get_instance_var_task = self.bot.loop.create_task(
+            self._get_instance_vars())
+        self._get_instance_vars_event = asyncio.Event()
+
+    async def _get_instance_vars(self) -> None:
+        """Get instance variables after they're aviable to get from the guild"""
+        await self.bot.wait_until_guild_available()
+        guild = self.bot.get_guild(Guild.id)
+        self._guests_role = guild.get_role(Roles.guests)
+        self._mod_log_channel = self.bot.get_channel(Channels.mod_log)
+        self._get_instance_vars_event.set()
+
+    @commands.command(aliases=("hush",))
+    async def silence(self, ctx: Context, duration: SilenceDurationConverter = 10) -> None:
+        """
+        Silence the current channel for `duration` minutes or `forever`
+
+        Duration is capped at 15 minutes for non-moderators.
+        """
+        await self._get_instance_vars_event.wait()
+        log.debug(f"{ctx.author} is silencing channel #{ctx.channel}")
+        if not await self._silence(ctx.channel, duration=duration):
+            await ctx.send(f"{Emojis.cross_mark} current channel is already silenced.")
+            return
+        if duration is None:
+            await ctx.send(f"{Emojis.check_mark} silenced current channel indefinitely.")
+            return
+
+        await ctx.send(f"{Emojis.check_mark} silenced current channel for {duration} minute(s).")
+        await asyncio.sleep(duration*60)
+
+        log.info("Unsilencing channel after set delay.")
+        await ctx.invoke(self.unsilence)
+
+    @commands.command(aliases=("unhush",))
+    async def unsilence(self, ctx: Context) -> None:
+        """Unsiilence the current channel."""
+        await self._get_instance_vars_event.wait()
+        log.debug(
+            f"Unsilencing channel #{ctx.channel} from {ctx.author}'s command.")
+        if await self._unsilence(ctx.channel):
+            await ctx.send(f"{Emojis.check_mark} unsilenced current channel.")
+
+    async def _silence(self, channel: TextChannel, duration: Optional[int]) -> bool:
+        """Silence `channel` for `self._guests_role`"""
+        current_overwrite = channel.overwrites_for(self._guests_role)
+        if current_overwrite.send_messages is False:
+            log.info(
+                f"Tried to silence channel #{channel} ({channel.id}) but the channel was already silenced.")
+            return False
+        await channel.set_permissions(self._guests_role, **dict(current_overwrite, send_messages=False))
+        self.muted_channels.add(channel)
+        if not duration:
+            log.info(f"Silenced #{channel} ({channel.id}) indefinitely.")
+            return True
+
+        log.info(
+            f"Silenced #{channel} ({channel.id}) for {duration} minute(s).")
+        return True
+
+    async def _unsilence(self, channel: TextChannel) -> bool:
+        """
+        Unsilence `channel`
+
+        Check if `channel` is silenced through `PermissionOverwrite`, if it is, unsilence it.
+        Return `True` if channel permissions were changed, `False` otherwise
+        """
+        current_overwrite = channel.overwrites_for(self._guests_role)
+        if current_overwrite.send_messages is False:
+            await channel.set_permissions(self._guests_role, **dict(current_overwrite, send_messages=None))
+            log.info(f"Unsilenced channel #{channel} ({channel.id}).")
+            self.muted_channels.discard(channel)
+            return True
+        log.info(
+            f"Tried to unsilence channel ${channel} ({channel.id}) but the channel was not silenced.")
+        return False
+
+    def cog_check(self, ctx: Context) -> bool:
+        """Only allow moderators to invoke the commands in this cog."""
+        return with_role_check(ctx, *STAFF_ROLES)


### PR DESCRIPTION
Closes #32 

**Introduce a channel muting system for staff.**
This will allow staff members to mute channels for up to 15 minutes, or moderators to mute them for longer times, or even permanently

**Command for silencing:**
- `!silence [duration]` (Duration is referring to a custom converter which can interpret durations like: `15m`, `15M` or simply `15`, `forever` can also be passed. The default value if nothing is passed is 10 minutes. This converter will raise `BadArgument` error when a number higher than 15/forever is passed by a non-moderator staff member)

As described in #32 this can be useful for forcing users to read the staff messages before they disappear because of spam and spam in general.

**The system looks like this**
![image](https://user-images.githubusercontent.com/20902250/83267557-ac9f3b80-a1c4-11ea-9430-89df9f4c4d48.png)
![image](https://user-images.githubusercontent.com/20902250/83267660-d6f0f900-a1c4-11ea-8ffc-2501a0ca8c50.png)
