### PR TITLE
Fix infraction description

### DIFF
--- a/bot/utils/infractions.py
+++ b/bot/utils/infractions.py
@@ -1,4 +1,3 @@
-# Infractions
 import datetime
 import logging
 

--- a/bot/utils/infractions.py
+++ b/bot/utils/infractions.py
@@ -1,3 +1,4 @@
+# Infractions
 import datetime
 import logging
 
@@ -26,7 +27,7 @@ class Infraction:
 
         self.user_id = user_id
         self.type = inf_type
-        self.reason = reason
+        self.reason = reason if reason is not None else "N/A"
         self.actor_id = actor_id
 
         if type(start) == datetime.datetime:


### PR DESCRIPTION
Closes #43 

Passing `None` to the description of infractions directly breaks infractions saving,
since SQLite method of parsing will ignore that completely, instead of passing an empty string for that value. Replacing `None` with `"N/A"` will solve this.

![image](https://user-images.githubusercontent.com/20902250/83688882-5b40e300-a5ee-11ea-9d68-339713b326c0.png)
