### PR TITLE
Merge `UnsilenceScheduler` to `Silence` directly

### DIFF
--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -20,39 +20,10 @@ from bot.utils.scheduling import Scheduler
 log = logging.getLogger(__name__)
 
 SilencedChannel = namedtuple(
-    "SilencedChannel", ("id", "ctx", "silence", "stop"))
+    "SilencedChannel", ("id", "ctx", "stop"))
 
 
-class UnsilenceScheduler(Scheduler):
-    """Scheduler for unsilencing channels"""
-
-    def __init__(self, bot: Bot):
-        super().__init__()
-
-        self.bot = bot
-
-    async def schedule_unsilence(self, channel: SilencedChannel) -> None:
-        """Schedule expiration for silenced channels"""
-        await self.bot.wait_until_guild_available()
-        log.debug("Scheduling unsilencer")
-        self.schedule_task(channel.id, channel)
-
-    async def _scheduled_task(self, channel: SilencedChannel) -> None:
-        """
-        Removes expired silenced channel from `silence.muted_channels`
-        and calls `silence.unsilence` to unsilence the channel
-        after the silence expires
-        """
-        await time.wait_until(channel.stop)
-
-        log.info("Unsilencing channel after set delay.")
-
-        # Because `silence.unsilence` explicitly cancels this scheduled task, it is shielded
-        # to avoid prematurely cancelling itself.
-        await asyncio.shield(channel.ctx.invoke(channel.silence.unsilence))
-
-
-class Silence(commands.Cog):
+class Silence(Scheduler, commands.Cog):
     """Commands for stopping channel messages for `Guest` role in a channel."""
 
     def __init__(self, bot: Bot):
@@ -61,7 +32,7 @@ class Silence(commands.Cog):
         self._get_instance_var_task = self.bot.loop.create_task(
             self._get_instance_vars())
         self._get_instance_vars_event = asyncio.Event()
-        self.scheduler = UnsilenceScheduler(bot)
+        super().__init__()
 
     @property
     def mod_log(self) -> ModLog:
@@ -75,6 +46,21 @@ class Silence(commands.Cog):
         self._guests_role = guild.get_role(Roles.guests)
         self._mod_log_channel = self.bot.get_channel(Channels.mod_log)
         self._get_instance_vars_event.set()
+
+    async def schedule_unsilence(self, channel: SilencedChannel) -> None:
+        """Schedule expiration for silenced channels."""
+        await self.bot.wait_until_guild_available()
+        log.debug("Scheduling unsilencer")
+        self.schedule_task(channel.id, channel)
+
+    async def _scheduled_task(self, channel: SilencedChannel) -> None:
+        """Calls `self.unsilence` on expired silenced channel to unsilence it."""
+        await time.wait_until(channel.stop)
+        log.info("Unsilencing channel after set delay.")
+
+        # Because `self.unsilence` explicitly cancels this scheduled tas, it is shielded
+        # to avoid prematurely cancelling itself
+        await asyncio.shield(channel.ctx.invoke(self.unsilence))
 
     @commands.command(aliases=("hush", "mutechat"))
     async def silence(self, ctx: Context, duration: SilenceDurationConverter = 10) -> None:
@@ -117,11 +103,10 @@ class Silence(commands.Cog):
         channel = SilencedChannel(
             id=ctx.channel.id,
             ctx=ctx,
-            silence=self,
             stop=datetime.datetime.now() + datetime.timedelta(minutes=duration),
         )
 
-        await self.scheduler.schedule_unsilence(channel)
+        await self.schedule_unsilence(channel)
 
     @commands.command(aliases=("unhush", "unmutechat"))
     async def unsilence(self, ctx: Context) -> None:
@@ -186,7 +171,7 @@ class Silence(commands.Cog):
             await channel.set_permissions(self._guests_role, **dict(current_overwrite, send_messages=None))
             log.info(f"Unsilenced channel #{channel} ({channel.id}).")
             self.muted_channels.discard(channel)
-            self.scheduler.cancel_task(channel.id)
+            self.cancel_task(channel.id)
             return True
         log.info(
             f"Tried to unsilence channel ${channel} ({channel.id}) but the channel was not silenced.")


### PR DESCRIPTION
Closes #48 
There is no point in having additional class solely for scheduling unsilence, we can simply merge this class directly into `Silence` cog as described in #48 